### PR TITLE
fix(api): accept any asset id shape on mobile partial check-out

### DIFF
--- a/apps/webapp/app/routes/api+/mobile+/bookings.partial-checkout.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.partial-checkout.ts
@@ -62,7 +62,11 @@ export async function action({ request }: ActionFunctionArgs) {
         // an empty `assetIds`. INDIVIDUAL rows still flow through `assetIds`. The
         // service 400s if BOTH are empty, so we don't require a minimum here
         // (mirrors the partial-checkin route).
-        assetIds: z.array(z.string().cuid()).optional(),
+        // Any non-empty id: asset ids come in more than one shape (imported
+        // and seeded rows carry ids that no single format check describes),
+        // and the id is proven against the booking downstream anyway. The
+        // check-in twin takes the same shape.
+        assetIds: z.array(z.string().min(1)).optional(),
         /**
          * Optional per-asset checkout payload mirroring the webapp check-in
          * JSON shape. When present, the service uses it to perform partial
@@ -73,8 +77,8 @@ export async function action({ request }: ActionFunctionArgs) {
         checkouts: z
           .array(
             z.object({
-              assetId: z.string().cuid(),
-              bookingAssetId: z.string().cuid().nullable().optional(),
+              assetId: z.string().min(1),
+              bookingAssetId: z.string().nullish(),
               quantity: z.number().int().positive(),
             })
           )

--- a/apps/webapp/test/routes-tests/api+/mobile+/bookings.partial-checkout.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/bookings.partial-checkout.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Validation contract for the mobile progressive check-out endpoint.
+ *
+ * The ids the app sends back are the ones it was given in the booking payload,
+ * and asset ids do not all share a single shape — imported and seeded rows
+ * carry ids no format check describes. So this route accepts any non-empty id
+ * and lets the service prove it against the booking, which is the check that
+ * actually protects anything. An id shaped differently from the majority must
+ * reach the service rather than being turned away at the door.
+ *
+ * @see {@link file://./bookings.partial-checkout.ts} route under test
+ * @see {@link file://./bookings.partial-checkin.ts} the twin it matches
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createActionArgs } from "@mocks/remix";
+
+import { db } from "~/database/db.server";
+import type * as MobileAuthServer from "~/modules/api/mobile-auth.server";
+import {
+  requireMobileAuth,
+  requireOrganizationAccess,
+  getMobileUserContext,
+} from "~/modules/api/mobile-auth.server";
+import type * as BookingServiceServer from "~/modules/booking/service.server";
+import { partialCheckoutBooking } from "~/modules/booking/service.server";
+
+import { action } from "~/routes/api+/mobile+/bookings.partial-checkout";
+
+import { assertIsDataWithResponseInit } from "@helpers/assertions";
+import { mobileUserContext } from "@helpers/mobile-user-context";
+
+// @vitest-environment node
+
+// why: db is the integration boundary — the route reads the booking to gate the
+// mutation on ownership. Nothing else here touches it.
+vi.mock("~/database/db.server", () => ({
+  db: { booking: { findFirst: vi.fn() } },
+}));
+
+// why: JWT validation, org-membership resolution and the permission gate are
+// out of scope for a validation test; the rest of the module stays real.
+vi.mock("~/modules/api/mobile-auth.server", async () => {
+  const actual = await vi.importActual<typeof MobileAuthServer>(
+    "~/modules/api/mobile-auth.server"
+  );
+  return {
+    ...actual,
+    requireMobileAuth: vi.fn(),
+    requireOrganizationAccess: vi.fn(),
+    requireMobilePermission: vi.fn(),
+    assertMobileCanUseBookings: vi.fn(),
+    getMobileUserContext: vi.fn(),
+  };
+});
+
+// why: the service is the seam past the validator — spying on it is how
+// "the payload was accepted" becomes observable.
+vi.mock("~/modules/booking/service.server", async () => {
+  const actual = await vi.importActual<typeof BookingServiceServer>(
+    "~/modules/booking/service.server"
+  );
+  return {
+    ...actual,
+    partialCheckoutBooking: vi.fn(),
+  };
+});
+
+// why: rate limiting is infra, not the behaviour under test — no-op it.
+vi.mock("~/utils/rate-limit.server", () => ({
+  enforceUserRateLimit: vi.fn().mockResolvedValue(undefined),
+}));
+
+const partialCheckoutBookingMock = vi.mocked(partialCheckoutBooking);
+
+const BOOKING_ID = "booking-1";
+/** An id that carries no leading "c" — the shape a format check turned away. */
+const IMPORTED_ASSET_ID = "a2oaa2njg9732b0m9lmhe5301";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(requireMobileAuth).mockResolvedValue({
+    user: { id: "user-1" },
+  } as Awaited<ReturnType<typeof requireMobileAuth>>);
+  vi.mocked(requireOrganizationAccess).mockResolvedValue("org-1");
+  vi.mocked(getMobileUserContext).mockResolvedValue(
+    mobileUserContext({ roles: [OrganizationRoles.ADMIN] })
+  );
+  vi.mocked(db.booking.findFirst).mockResolvedValue({
+    creatorId: "user-1",
+    custodianUserId: "user-1",
+  } as never);
+  partialCheckoutBookingMock.mockResolvedValue({
+    checkedOutAssetCount: 1,
+    remainingAssetCount: 0,
+    isComplete: true,
+    booking: { id: BOOKING_ID, name: "Load-in", status: "ONGOING" },
+  } as never);
+});
+
+async function post(body: Record<string, unknown>) {
+  return action(
+    createActionArgs({
+      request: new Request(
+        "http://localhost:3000/api/mobile/bookings/partial-checkout",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ bookingId: BOOKING_ID, ...body }),
+        }
+      ),
+      params: {},
+    })
+  );
+}
+
+describe("POST /api/mobile/bookings/partial-checkout — which ids it accepts", () => {
+  it("passes an asset id of any shape through to the service", async () => {
+    const response = await post({ assetIds: [IMPORTED_ASSET_ID] });
+
+    assertIsDataWithResponseInit(response);
+    expect(response.init?.status ?? 200).toBe(200);
+    expect(partialCheckoutBookingMock).toHaveBeenCalledWith(
+      expect.objectContaining({ assetIds: [IMPORTED_ASSET_ID] })
+    );
+  });
+
+  it("passes a quantity payload of any shape through to the service", async () => {
+    await post({
+      checkouts: [
+        {
+          assetId: IMPORTED_ASSET_ID,
+          bookingAssetId: "slice-without-a-c",
+          quantity: 2,
+        },
+      ],
+    });
+
+    expect(partialCheckoutBookingMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        checkouts: [
+          {
+            assetId: IMPORTED_ASSET_ID,
+            bookingAssetId: "slice-without-a-c",
+            quantity: 2,
+          },
+        ],
+      })
+    );
+  });
+
+  it("still refuses an empty id", async () => {
+    const response = await post({ assetIds: [""] });
+
+    assertIsDataWithResponseInit(response);
+    expect(response.init?.status).toBe(400);
+    expect(partialCheckoutBookingMock).not.toHaveBeenCalled();
+  });
+
+  it("still refuses a quantity that is not a positive whole number", async () => {
+    const response = await post({
+      checkouts: [{ assetId: IMPORTED_ASSET_ID, quantity: 0 }],
+    });
+
+    assertIsDataWithResponseInit(response);
+    expect(response.init?.status).toBe(400);
+    expect(partialCheckoutBookingMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/test/routes-tests/api+/mobile+/bookings.partial-checkout.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/bookings.partial-checkout.test.ts
@@ -67,11 +67,6 @@ vi.mock("~/modules/booking/service.server", async () => {
   };
 });
 
-// why: rate limiting is infra, not the behaviour under test — no-op it.
-vi.mock("~/utils/rate-limit.server", () => ({
-  enforceUserRateLimit: vi.fn().mockResolvedValue(undefined),
-}));
-
 const partialCheckoutBookingMock = vi.mocked(partialCheckoutBooking);
 
 const BOOKING_ID = "booking-1";


### PR DESCRIPTION
## What

Progressive check-out from the companion app rejected the request outright when a
selected asset's id did not match a `cuid()` format check, answering with the
opaque message **"Invalid cuid"**. The operator saw a failure with nothing to act on.

## Why it was wrong

Asset ids do not all share one shape — imported and seeded rows carry ids that no
single format check describes — so the endpoint refused work it was perfectly able
to do.

The ids in question come straight back from the booking payload the app was just
given, and `partialCheckoutBooking` proves each one belongs to the booking before
touching it. That ownership check is what actually protects anything here; the
format check added nothing on top of it.

The check-in twin this route was written alongside
(`bookings.partial-checkin.ts:61`, `:69-70`) already accepts any non-empty id.
These were the only three `.cuid()` uses left in the mobile API.

## The change

`bookings.partial-checkout.ts` — three schema fields go from `.cuid()` to the
shapes the check-in route uses:

| Field | Before | After |
| --- | --- | --- |
| `assetIds[]` | `z.string().cuid()` | `z.string().min(1)` |
| `checkouts[].assetId` | `z.string().cuid()` | `z.string().min(1)` |
| `checkouts[].bookingAssetId` | `z.string().cuid().nullable().optional()` | `z.string().nullish()` |

Empty ids and non-positive quantities are still refused.

## Tests

New `test/routes-tests/api+/mobile+/bookings.partial-checkout.test.ts` (4 tests):
an id of any shape reaches the service, a quantity payload of any shape reaches the
service, an empty id is still refused, a non-positive quantity is still refused.

Verified as a real regression guard: with the schema change reverted, 2 of the 4
fail; with it, all 4 pass.

## How this was found

Driving the companion on the simulator against a local server: selecting a kit's
members for check-out returned 400 for every attempt. Reproduced against a booking
whose asset ids happen not to start with `c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Mobile partial checkout now accepts valid, non-empty asset identifiers in different formats, including imported or seeded records.
  - Empty asset identifiers and non-positive quantities continue to be rejected.
  - Identifiers are still validated against the associated booking during checkout.

- **Tests**
  - Added coverage for varied identifier formats and invalid checkout requests, including confirmation that rejected requests do not proceed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->