### PR TITLE
fix(api): resolve barcode values that look like SAM IDs

### DIFF
--- a/apps/webapp/app/modules/api/mobile-code-resolve.server.test.ts
+++ b/apps/webapp/app/modules/api/mobile-code-resolve.server.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { db } from "~/database/db.server";
@@ -70,11 +71,28 @@ function resolveArgs(qrId = "abcdefghij") {
 
 const qrFindUnique = vi.mocked(db.qr.findUnique);
 const membershipFindUnique = vi.mocked(db.userOrganization.findUnique);
-const assetFindFirst = vi.mocked(db.asset.findFirst);
-const organizationFindUnique = vi.mocked(db.organization.findUnique);
 const requireOrgAccess = vi.mocked(requireOrganizationAccess);
 const barcodeByValue = vi.mocked(getBarcodeByValue);
 const barcodesCapability = vi.mocked(canUseBarcodes);
+
+/**
+ * The two handles the SAM tests drive, narrowed to the shape the resolver
+ * actually reads.
+ *
+ * Both queries use `select`, so Prisma hands the resolver a few columns and
+ * never a whole row — but the mocked client's signature still asks for one.
+ * Widening happens once, here, instead of at every fixture: building full
+ * Prisma rows would describe data the resolver never sees, and a per-fixture
+ * cast would switch off checking on the values under test. With the handle
+ * typed, a mistyped column (`barcodeEnabled`) fails the build rather than
+ * silently flipping a gate at runtime.
+ */
+const assetFindFirst = db.asset.findFirst as unknown as Mock<
+  () => Promise<{ id: string; title: string } | null>
+>;
+const organizationFindUnique = db.organization.findUnique as unknown as Mock<
+  () => Promise<{ barcodesEnabled: boolean } | null>
+>;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -223,7 +241,7 @@ describe("resolveMobileScannedCode SAM-shaped barcode fallback", () => {
     requireOrgAccess.mockResolvedValue(ORG_ID);
     // Default posture: the workspace holds the add-on, so each test only has
     // to state what it changes.
-    organizationFindUnique.mockResolvedValue({ barcodesEnabled: true } as any);
+    organizationFindUnique.mockResolvedValue({ barcodesEnabled: true });
     barcodesCapability.mockReturnValue(true);
   });
 
@@ -289,7 +307,7 @@ describe("resolveMobileScannedCode SAM-shaped barcode fallback", () => {
     // why: the barcode table is add-on data — a workspace without the add-on
     // must not resolve through it, and must not be told the row exists.
     assetFindFirst.mockResolvedValue(null);
-    organizationFindUnique.mockResolvedValue({ barcodesEnabled: false } as any);
+    organizationFindUnique.mockResolvedValue({ barcodesEnabled: false });
     barcodesCapability.mockReturnValue(false);
 
     const result = await resolveMobileScannedCode(resolveArgs(SAM_SHAPED));
@@ -327,10 +345,7 @@ describe("resolveMobileScannedCode SAM-shaped barcode fallback", () => {
   it("resolves a real SAM id without touching the barcode table", async () => {
     // why: the SAM id is the core identifier — a value that is both a SAM id
     // and a barcode resolves as the SAM, and costs no extra query.
-    assetFindFirst.mockResolvedValue({
-      id: "asset-9",
-      title: "Asset nine",
-    } as any);
+    assetFindFirst.mockResolvedValue({ id: "asset-9", title: "Asset nine" });
 
     const result = await resolveMobileScannedCode(resolveArgs(SAM_SHAPED));
 

--- a/apps/webapp/app/modules/api/mobile-code-resolve.server.test.ts
+++ b/apps/webapp/app/modules/api/mobile-code-resolve.server.test.ts
@@ -1,20 +1,40 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { db } from "~/database/db.server";
+import { requireOrganizationAccess } from "~/modules/api/mobile-auth.server";
 import { resolveMobileScannedCode } from "~/modules/api/mobile-code-resolve.server";
+import { getBarcodeByValue } from "~/modules/barcode/service.server";
+import { canUseBarcodes } from "~/utils/subscription.server";
 
 // why: importing the module transitively loads `~/database/db.server`, which
 // instantiates a real Prisma client and tries to connect at module load —
 // under `pnpm test:run` (no DB available) that fails the suite. The resolver
 // only touches `qr.findUnique`, `userOrganization.findUnique`,
-// `asset.findFirst` and `kit.findFirst`, so we stub exactly those.
+// `asset.findFirst`, `kit.findFirst` and `organization.findUnique` (the
+// Barcodes add-on gate on the SAM fallback), so we stub exactly those.
 vi.mock("~/database/db.server", () => ({
   db: {
     qr: { findUnique: vi.fn() },
     userOrganization: { findUnique: vi.fn() },
     asset: { findFirst: vi.fn() },
     kit: { findFirst: vi.fn() },
+    organization: { findUnique: vi.fn() },
   },
+}));
+
+// why: the SAM fallback reads the workspace's barcode table through this
+// service. Stubbing it keeps the branch under test free of a database and
+// makes "did we even look?" assertable — the add-on-off case must not query.
+vi.mock("~/modules/barcode/service.server", () => ({
+  getBarcodeByValue: vi.fn(),
+}));
+
+// why: `subscription.server` pulls in the Stripe client and the whole billing
+// config at module load. Stubbing the one capability helper also puts the
+// add-on gate under explicit control, so these tests do not depend on the
+// ambient `ENABLE_PREMIUM_FEATURES` value.
+vi.mock("~/utils/subscription.server", () => ({
+  canUseBarcodes: vi.fn(),
 }));
 
 // why: `mobile-auth.server` transitively loads the Supabase admin client
@@ -50,6 +70,11 @@ function resolveArgs(qrId = "abcdefghij") {
 
 const qrFindUnique = vi.mocked(db.qr.findUnique);
 const membershipFindUnique = vi.mocked(db.userOrganization.findUnique);
+const assetFindFirst = vi.mocked(db.asset.findFirst);
+const organizationFindUnique = vi.mocked(db.organization.findUnique);
+const requireOrgAccess = vi.mocked(requireOrganizationAccess);
+const barcodeByValue = vi.mocked(getBarcodeByValue);
+const barcodesCapability = vi.mocked(canUseBarcodes);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -169,5 +194,159 @@ describe("resolveMobileScannedCode failure discrimination", () => {
         kit: null,
       },
     });
+  });
+});
+
+/**
+ * The SAM branch's barcode fallback.
+ *
+ * A workspace can print labels whose value looks like a SAM id but is
+ * registered as a barcode. The companion routes every SAM-shaped scan to the
+ * SAM resolver, so without this fallback those labels never resolve.
+ *
+ * @see {@link file://./mobile-code-resolve.server.ts} `resolveSamShapedBarcode`
+ */
+describe("resolveMobileScannedCode SAM-shaped barcode fallback", () => {
+  const ORG_ID = "org-1";
+  /** A value that satisfies the SAM id pattern but is stored as a barcode. */
+  const SAM_SHAPED = "SAM-0001";
+
+  /** The SAM 404 the resolver returns when nothing matches the scanned value. */
+  const SAM_NOT_FOUND = {
+    ok: false,
+    status: 404,
+    message:
+      "This SAM ID doesn't exist or it doesn't belong to your current organization.",
+  };
+
+  beforeEach(() => {
+    requireOrgAccess.mockResolvedValue(ORG_ID);
+    // Default posture: the workspace holds the add-on, so each test only has
+    // to state what it changes.
+    organizationFindUnique.mockResolvedValue({ barcodesEnabled: true } as any);
+    barcodesCapability.mockReturnValue(true);
+  });
+
+  it("resolves an asset-linked barcode when no asset carries that SAM id", async () => {
+    assetFindFirst.mockResolvedValue(null);
+    barcodeByValue.mockResolvedValue({
+      value: SAM_SHAPED,
+      assetId: "asset-1",
+      kitId: null,
+      asset: { id: "asset-1", title: "Asset one" },
+      kit: null,
+    });
+
+    const result = await resolveMobileScannedCode(resolveArgs(SAM_SHAPED));
+
+    expect(result).toEqual({
+      ok: true,
+      // A barcode has no QR row, so there is nothing to attribute a scan to.
+      recordableQrId: null,
+      qr: {
+        id: SAM_SHAPED,
+        assetId: "asset-1",
+        kitId: null,
+        organizationId: ORG_ID,
+        asset: { id: "asset-1", title: "Asset one" },
+        kit: null,
+      },
+    });
+    // The raw scanned string is what reaches the barcode table — the helper
+    // matches original case first, then uppercase.
+    expect(barcodeByValue).toHaveBeenCalledWith(
+      expect.objectContaining({ value: SAM_SHAPED, organizationId: ORG_ID })
+    );
+  });
+
+  it("resolves a kit-linked barcode with the kit shaped as the QR path shapes it", async () => {
+    assetFindFirst.mockResolvedValue(null);
+    barcodeByValue.mockResolvedValue({
+      value: SAM_SHAPED,
+      assetId: null,
+      kitId: "kit-1",
+      asset: null,
+      kit: { id: "kit-1", name: "Kit one" },
+    });
+
+    const result = await resolveMobileScannedCode(resolveArgs(SAM_SHAPED));
+
+    expect(result).toEqual({
+      ok: true,
+      recordableQrId: null,
+      qr: {
+        id: SAM_SHAPED,
+        assetId: null,
+        kitId: "kit-1",
+        organizationId: ORG_ID,
+        asset: null,
+        kit: { id: "kit-1", name: "Kit one" },
+      },
+    });
+  });
+
+  it("keeps the SAM 404 and never reads the barcode table without the add-on", async () => {
+    // why: the barcode table is add-on data — a workspace without the add-on
+    // must not resolve through it, and must not be told the row exists.
+    assetFindFirst.mockResolvedValue(null);
+    organizationFindUnique.mockResolvedValue({ barcodesEnabled: false } as any);
+    barcodesCapability.mockReturnValue(false);
+
+    const result = await resolveMobileScannedCode(resolveArgs(SAM_SHAPED));
+
+    expect(result).toEqual(SAM_NOT_FOUND);
+    expect(barcodeByValue).not.toHaveBeenCalled();
+  });
+
+  it("keeps the SAM 404 when the barcode exists but is linked to nothing", async () => {
+    // why: an unlinked barcode resolves to no item, and the response must not
+    // reveal that a row exists for it.
+    assetFindFirst.mockResolvedValue(null);
+    barcodeByValue.mockResolvedValue({
+      value: SAM_SHAPED,
+      assetId: null,
+      kitId: null,
+      asset: null,
+      kit: null,
+    });
+
+    const result = await resolveMobileScannedCode(resolveArgs(SAM_SHAPED));
+
+    expect(result).toEqual(SAM_NOT_FOUND);
+  });
+
+  it("keeps the SAM 404 when the workspace holds no such barcode", async () => {
+    assetFindFirst.mockResolvedValue(null);
+    barcodeByValue.mockResolvedValue(null);
+
+    const result = await resolveMobileScannedCode(resolveArgs(SAM_SHAPED));
+
+    expect(result).toEqual(SAM_NOT_FOUND);
+  });
+
+  it("resolves a real SAM id without touching the barcode table", async () => {
+    // why: the SAM id is the core identifier — a value that is both a SAM id
+    // and a barcode resolves as the SAM, and costs no extra query.
+    assetFindFirst.mockResolvedValue({
+      id: "asset-9",
+      title: "Asset nine",
+    } as any);
+
+    const result = await resolveMobileScannedCode(resolveArgs(SAM_SHAPED));
+
+    expect(result).toEqual({
+      ok: true,
+      recordableQrId: null,
+      qr: {
+        id: SAM_SHAPED,
+        assetId: "asset-9",
+        kitId: null,
+        organizationId: ORG_ID,
+        asset: { id: "asset-9", title: "Asset nine" },
+        kit: null,
+      },
+    });
+    expect(barcodeByValue).not.toHaveBeenCalled();
+    expect(organizationFindUnique).not.toHaveBeenCalled();
   });
 });

--- a/apps/webapp/app/modules/api/mobile-code-resolve.server.ts
+++ b/apps/webapp/app/modules/api/mobile-code-resolve.server.ts
@@ -2,7 +2,9 @@
  * Mobile scanned-code resolver (shared)
  *
  * Resolves a scanned QR id or SAM / sequential id to its linked asset or kit,
- * enforcing organization membership. It deliberately does NOT record scan
+ * enforcing organization membership. A SAM-shaped value the workspace has no
+ * asset for falls back to its barcode table, so labels printed with a
+ * SAM-shaped barcode value still resolve. It deliberately does NOT record scan
  * provenance: recording is the *caller's* (the endpoint's) decision.
  *
  * This is the seam that keeps the recording vs non-recording behaviour an
@@ -29,8 +31,10 @@ import {
   shapeMobileAssetResponse,
   shapeMobileKitResponse,
 } from "~/modules/api/mobile-auth.server";
+import { getBarcodeByValue } from "~/modules/barcode/service.server";
 import { getParams } from "~/utils/http.server";
 import { parseSequentialId } from "~/utils/sequential-id";
+import { canUseBarcodes } from "~/utils/subscription.server";
 
 /** The resolved code payload returned to the companion (shared by both routes). */
 type ResolvedCode = {
@@ -83,6 +87,97 @@ export type ResolveMobileCodeResult =
   | { ok: true; qr: ResolvedCode; recordableQrId: string | null };
 
 /**
+ * A barcode row carrying just what a mobile resolve needs.
+ *
+ * The relation types are borrowed from the shape helpers rather than declared
+ * again, so widening `MOBILE_ASSET_SELECT` / `MOBILE_KIT_SELECT` cannot leave
+ * this type behind. `getBarcodeByValue` is generic over its `include` and
+ * returns `any`, so annotating the call site is what keeps the payload typed.
+ */
+type MobileBarcodeMatch = {
+  value: string;
+  assetId: string | null;
+  kitId: string | null;
+  asset: Parameters<typeof shapeMobileAssetResponse>[0] | null;
+  kit: Parameters<typeof shapeMobileKitResponse>[0];
+};
+
+/**
+ * Resolve a SAM-shaped scan against the workspace's barcode table.
+ *
+ * Reserved for values the SAM lookup already missed — a SAM id is the core
+ * identifier and always wins, so a value that is both resolves as the SAM.
+ *
+ * Gated on the Barcodes add-on because the barcode table is add-on data:
+ * resolving through it for a workspace without the add-on would hand out what
+ * the add-on sells. Uses `canUseBarcodes` rather than reading `barcodesEnabled`
+ * directly so a self-hosted deployment — which has no billing to gate on and
+ * therefore holds every add-on — is not refused; the mobile barcode route
+ * gates the same way.
+ *
+ * Scoped to the caller's own workspace only. The mobile barcode route also
+ * searches sibling workspaces so it can offer a switch, but a SAM-shaped value
+ * arrives here as a SAM candidate, and SAM resolution never leaves the current
+ * workspace.
+ *
+ * @param args.value - The raw scanned string, exactly as the route received it.
+ * @param args.organizationId - The caller's current workspace.
+ * @returns An ok result when the value is a barcode LINKED to an asset or kit,
+ *   otherwise `null` so the caller can fall through to its own not-found. An
+ *   unlinked barcode returns `null` too: the response must not reveal that a
+ *   row exists for a code that resolves to nothing.
+ * @see {@link file://./../../routes/api+/mobile+/barcode.$value.ts}
+ */
+async function resolveSamShapedBarcode({
+  value,
+  organizationId,
+}: {
+  value: string;
+  organizationId: string;
+}): Promise<ResolveMobileCodeResult | null> {
+  const organization = await db.organization.findUnique({
+    where: { id: organizationId },
+    select: { barcodesEnabled: true },
+  });
+
+  if (!organization || !canUseBarcodes(organization)) {
+    return null;
+  }
+
+  const barcode: MobileBarcodeMatch | null = await getBarcodeByValue({
+    value,
+    organizationId,
+    include: {
+      asset: { select: MOBILE_ASSET_SELECT },
+      kit: { select: MOBILE_KIT_SELECT },
+    },
+  });
+
+  if (!barcode || (!barcode.assetId && !barcode.kitId)) {
+    return null;
+  }
+
+  return {
+    ok: true,
+    // A barcode has no QR record, so there is nothing to record a scan
+    // against — same as a SAM resolve.
+    recordableQrId: null,
+    qr: {
+      // The stored barcode value, which may differ in case from what was
+      // scanned; the companion echoes this id back on follow-up calls.
+      id: barcode.value,
+      assetId: barcode.assetId,
+      kitId: barcode.kitId,
+      organizationId,
+      // Flatten the pivot shape (assetKits/assetLocations/custody) into the
+      // legacy flat shape the companion expects, exactly as the QR path does.
+      asset: barcode.asset ? shapeMobileAssetResponse(barcode.asset) : null,
+      kit: shapeMobileKitResponse(barcode.kit),
+    },
+  };
+}
+
+/**
  * Resolve a scanned code to its asset/kit, enforcing org membership.
  *
  * @param args.request - The loader request (for SAM org context).
@@ -104,8 +199,9 @@ export async function resolveMobileScannedCode({
 
   // ── SAM / sequential ID path (web parity) ──
   // SAM ids are unique per-org (not global like a QR id), so resolution needs
-  // the caller's workspace. Core identifier, NOT gated behind the Barcodes
-  // add-on (matches web, where SAM resolution sits in the qr-read path).
+  // the caller's workspace. The SAM lookup is a core identifier and NOT gated
+  // behind the Barcodes add-on (matches web, where SAM resolution sits in the
+  // qr-read path); only the barcode fallback below carries that gate.
   const sequentialId = parseSequentialId(qrId);
   if (sequentialId) {
     const organizationId = await requireOrganizationAccess(request, user.id);
@@ -115,6 +211,22 @@ export async function resolveMobileScannedCode({
     });
 
     if (!asset) {
+      // A printed label can carry a SAM-shaped value that the workspace
+      // registered as a BARCODE rather than as the asset's SAM id. The
+      // companion cannot tell the two apart from the decoded string, so it
+      // routes every SAM-shaped scan here; without this fallback such a label
+      // dead-ends on the 404 below even though the workspace holds the code.
+      const fromBarcode = await resolveSamShapedBarcode({
+        // The raw scanned string, not the normalized SAM id: barcode values
+        // are matched original-case first, then uppercased.
+        value: qrId,
+        organizationId,
+      });
+
+      if (fromBarcode) {
+        return fromBarcode;
+      }
+
       return {
         ok: false,
         status: 404,

--- a/apps/webapp/app/routes/api+/get-scanned-item.$qrId.ts
+++ b/apps/webapp/app/routes/api+/get-scanned-item.$qrId.ts
@@ -3,7 +3,9 @@ import { data } from "react-router";
 import type { LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
 import { db } from "~/database/db.server";
+import type { AssetWithResolvableImage } from "~/modules/asset/image-resolution";
 import { serializeAssetImage } from "~/modules/asset/image-resolution";
+import { getBarcodeByValue } from "~/modules/barcode/service.server";
 import { getQr } from "~/modules/qr/service.server";
 import {
   getScannerPickerMeta,
@@ -42,13 +44,95 @@ import { parseSequentialId } from "~/utils/sequential-id";
 export type AssetFromQr = AssetFromScanner;
 export type KitFromQr = KitFromScanner;
 
+/**
+ * A barcode row carrying just what this loader needs to answer with.
+ *
+ * `getBarcodeByValue` is generic over its `include` and returns `any`, so
+ * annotating the call site is what keeps the fallback's payload typed. Only
+ * the relations are declared: the fallback decides what a barcode resolves to
+ * from the loaded asset or kit, the same way the QR branch does.
+ */
+type ScannedBarcodeMatch = {
+  asset: (AssetWithResolvableImage & { id: string }) | null;
+  kit: KitFromScanner | null;
+};
+
+/**
+ * Serialize an asset the way every lookup in this loader answers with it.
+ *
+ * Collapses the model-image cascade into the flat image fields the scanner
+ * drawers read — the nested relation is dropped so the row carries one source
+ * of truth for the image — then attaches the audit counters and, when the
+ * scanner named a destination, the same strict-available pool the
+ * manage-assets picker shows.
+ *
+ * Shared by all three lookups (SAM id, QR code, SAM-shaped barcode) so a
+ * scanned asset carries identical fields whichever one matched.
+ *
+ * @param args.asset - The asset row, fetched with `ASSET_INCLUDE`.
+ * @param args.organizationId - The caller's workspace, for the picker bound.
+ * @param args.auditSessionId - Audit session to count notes and images against.
+ * @param args.pickerContext - Destination the scanner is filling, if any.
+ * @returns The asset as the endpoint responds with it.
+ */
+async function serializeScannedAsset<
+  T extends AssetWithResolvableImage & { id: string },
+>({
+  asset,
+  organizationId,
+  auditSessionId,
+  pickerContext,
+}: {
+  asset: T;
+  organizationId: string;
+  auditSessionId?: string;
+  pickerContext?: ReturnType<typeof ScannerPickerContextSchema.parse>;
+}) {
+  let auditAssetId: string | undefined;
+  let auditNotesCount = 0;
+  let auditImagesCount = 0;
+
+  if (auditSessionId) {
+    const auditAsset = await db.auditAsset.findFirst({
+      where: { auditSessionId, assetId: asset.id },
+      select: { id: true },
+    });
+    auditAssetId = auditAsset?.id;
+
+    if (auditAssetId) {
+      const [notesCount, imagesCount] = await Promise.all([
+        db.auditNote.count({ where: { auditSessionId, auditAssetId } }),
+        db.auditImage.count({ where: { auditSessionId, auditAssetId } }),
+      ]);
+      auditNotesCount = notesCount;
+      auditImagesCount = imagesCount;
+    }
+  }
+
+  const pickerMeta: ScannerPickerMeta | null = pickerContext
+    ? await getScannerPickerMeta({
+        assetId: asset.id,
+        organizationId,
+        context: pickerContext,
+      })
+    : null;
+
+  return {
+    ...serializeAssetImage(asset),
+    auditAssetId,
+    auditNotesCount,
+    auditImagesCount,
+    pickerMeta,
+  };
+}
+
 export async function loader({ request, params, context }: LoaderFunctionArgs) {
   const authSession = context.getSession();
   const { userId } = authSession;
   const searchParams = getCurrentSearchParams(request);
 
   try {
-    const { organizationId } = await requirePermission({
+    const { organizationId, canUseBarcodes } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.qr,
@@ -148,81 +232,80 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
         include: assetInclude,
       });
 
-      if (!asset) {
-        throw new ShelfError({
-          cause: null,
-          message:
-            "This SAM ID doesn't exist or it doesn't belong to your current organization.",
-          title: "SAM ID not found",
-          additionalData: { sequentialId, shouldSendNotification: false },
-          label: "Scan",
-          shouldBeCaptured: false,
-        });
-      }
-
-      // If audit session ID provided, fetch the auditAssetId and counts
-      let auditAssetId: string | undefined;
-      let auditNotesCount = 0;
-      let auditImagesCount = 0;
-      if (auditSessionId && asset.id) {
-        const auditAsset = await db.auditAsset.findFirst({
-          where: {
-            auditSessionId,
-            assetId: asset.id,
-          },
-          select: { id: true },
-        });
-        auditAssetId = auditAsset?.id;
-        if (auditAssetId) {
-          const [notesCount, imagesCount] = await Promise.all([
-            db.auditNote.count({
-              where: {
+      if (asset) {
+        return data(
+          payload({
+            qr: {
+              type: "asset" as const,
+              asset: await serializeScannedAsset({
+                asset,
+                organizationId,
                 auditSessionId,
-                auditAssetId,
-              },
-            }),
-            db.auditImage.count({
-              where: {
-                auditSessionId,
-                auditAssetId,
-              },
-            }),
-          ]);
-          auditNotesCount = notesCount;
-          auditImagesCount = imagesCount;
-        }
-      }
-
-      // When the scanner provides a destination (location / kit /
-      // booking), attach the same strict-available pool the
-      // manage-assets picker shows so the row label + qty input bound
-      // are consistent across both UX surfaces.
-      const pickerMeta: ScannerPickerMeta | null =
-        pickerContext && asset.id
-          ? await getScannerPickerMeta({
-              assetId: asset.id,
-              organizationId,
-              context: pickerContext,
-            })
-          : null;
-
-      return data(
-        payload({
-          qr: {
-            type: "asset" as const,
-            asset: {
-              // Collapse the model-image cascade into the flat image fields
-              // the scanner drawers read; the nested relation is dropped so
-              // the row carries one source of truth for the image.
-              ...serializeAssetImage(asset),
-              auditAssetId,
-              auditNotesCount,
-              auditImagesCount,
-              pickerMeta,
+                pickerContext,
+              }),
             },
-          },
-        })
-      );
+          })
+        );
+      }
+
+      // A printed label can carry a SAM-shaped value that the workspace
+      // registered as a BARCODE rather than as an asset's SAM id. Scanner mode
+      // (keyboard wedge or typed input) tests the SAM pattern before anything
+      // else and sends every match here, so without this fallback those labels
+      // dead-end on the error below even though the workspace holds the code.
+      // Camera scans escape it already: they carry their symbology and go to
+      // `get-scanned-barcode` instead.
+      //
+      // Gated on `canUseBarcodes` — the flag `requirePermission` resolves from
+      // the workspace — so this endpoint refuses barcode data on exactly the
+      // same terms as its camera-scan sibling.
+      const barcode: ScannedBarcodeMatch | null = canUseBarcodes
+        ? await getBarcodeByValue({
+            // The raw scanned string, not the normalized SAM id: barcode
+            // values are matched original-case first, then uppercased.
+            value: qrId,
+            organizationId,
+            include: {
+              asset: { include: assetInclude },
+              kit: { include: kitInclude },
+            },
+          })
+        : null;
+
+      if (barcode?.asset) {
+        return data(
+          payload({
+            qr: {
+              type: "asset" as const,
+              asset: await serializeScannedAsset({
+                asset: barcode.asset,
+                organizationId,
+                auditSessionId,
+                pickerContext,
+              }),
+            },
+          })
+        );
+      }
+
+      if (barcode?.kit) {
+        return data(
+          payload({ qr: { type: "kit" as const, kit: barcode.kit } })
+        );
+      }
+
+      // Nothing carries this value. A barcode that exists but is linked to
+      // neither an asset nor a kit lands here too: it resolves to no item, and
+      // the response must not reveal that a row exists for it.
+      throw new ShelfError({
+        cause: null,
+        message:
+          "This SAM ID doesn't exist or it doesn't belong to your current organization.",
+        title: "SAM ID not found",
+        additionalData: { sequentialId, shouldSendNotification: false },
+        label: "Scan",
+        shouldBeCaptured: false,
+      });
     }
 
     const include = {
@@ -257,67 +340,18 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
       });
     }
 
-    // If audit session ID provided, fetch the auditAssetId and counts
-    let auditAssetId: string | undefined;
-    let auditNotesCount = 0;
-    let auditImagesCount = 0;
-    if (auditSessionId && qr.asset?.id) {
-      const auditAsset = await db.auditAsset.findFirst({
-        where: {
-          auditSessionId,
-          assetId: qr.asset.id,
-        },
-        select: { id: true },
-      });
-      auditAssetId = auditAsset?.id;
-      if (auditAssetId) {
-        const [notesCount, imagesCount] = await Promise.all([
-          db.auditNote.count({
-            where: {
-              auditSessionId,
-              auditAssetId,
-            },
-          }),
-          db.auditImage.count({
-            where: {
-              auditSessionId,
-              auditAssetId,
-            },
-          }),
-        ]);
-        auditNotesCount = notesCount;
-        auditImagesCount = imagesCount;
-      }
-    }
-
-    // See the sequential-id branch above for context. Same attachment
-    // shape so consumers can read `qr.asset.pickerMeta` regardless of
-    // which lookup matched.
-    const pickerMeta: ScannerPickerMeta | null =
-      pickerContext && qr.asset?.id
-        ? await getScannerPickerMeta({
-            assetId: qr.asset.id,
-            organizationId,
-            context: pickerContext,
-          })
-        : null;
-
     return data(
       payload({
         qr: {
           ...qr,
           type: qr.asset ? "asset" : qr.kit ? "kit" : undefined,
           asset: qr.asset
-            ? {
-                // Collapse the model-image cascade into the flat image
-                // fields the scanner drawers read; the nested relation is
-                // dropped so the row carries one source of truth.
-                ...serializeAssetImage(qr.asset),
-                auditAssetId,
-                auditNotesCount,
-                auditImagesCount,
-                pickerMeta,
-              }
+            ? await serializeScannedAsset({
+                asset: qr.asset,
+                organizationId,
+                auditSessionId,
+                pickerContext,
+              })
             : undefined,
         },
       })

--- a/apps/webapp/test/routes-tests/api+/get-scanned-item.$qrId.test.ts
+++ b/apps/webapp/test/routes-tests/api+/get-scanned-item.$qrId.test.ts
@@ -1,0 +1,239 @@
+// @vitest-environment node
+/**
+ * Web scanned-item resolve — the SAM-shaped barcode fallback.
+ *
+ * Scanner mode (keyboard wedge or typed input, the default on md+ viewports)
+ * tests the SAM id pattern before anything else and sends every match to this
+ * endpoint. A workspace that prints labels whose value looks like a SAM id but
+ * is registered as a barcode therefore never reaches `get-scanned-barcode`,
+ * which is where camera scans go.
+ *
+ * These pin the fallback and the unchanged SAM error either side of it. The
+ * error message is byte-matched on purpose: `resolveAssetIdFromSamId` carries
+ * the same string as its client-side default.
+ *
+ * @see {@link file://./../../../app/routes/api+/get-scanned-item.$qrId.ts}
+ * @see {@link file://./../scanner-sam-id.test.ts}
+ */
+
+const { mockRequirePermission } = vi.hoisted(() => ({
+  mockRequirePermission: vi.fn(),
+}));
+// why: the RBAC gate is not under test — it must PASS so the assertions are
+// about what the loader does with the scanned value. It also carries
+// `canUseBarcodes`, which is the add-on gate these tests drive.
+vi.mock("~/utils/roles.server", () => ({
+  requirePermission: mockRequirePermission,
+}));
+
+const {
+  mockAssetFindFirst,
+  mockAuditAssetFindFirst,
+  mockAuditNoteCount,
+  mockAuditImageCount,
+} = vi.hoisted(() => ({
+  mockAssetFindFirst: vi.fn(),
+  mockAuditAssetFindFirst: vi.fn(),
+  mockAuditNoteCount: vi.fn(),
+  mockAuditImageCount: vi.fn(),
+}));
+// why: importing the route pulls in `db.server`, whose non-production
+// initialization calls `db.$connect()` — without this the test opens a real
+// PostgreSQL connection. `asset.findFirst` is the SAM lookup these tests drive;
+// the audit counters are only reached with an `auditSessionId`, which none of
+// these requests carry.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    $connect: vi.fn(),
+    asset: { findFirst: mockAssetFindFirst },
+    auditAsset: { findFirst: mockAuditAssetFindFirst },
+    auditNote: { count: mockAuditNoteCount },
+    auditImage: { count: mockAuditImageCount },
+  },
+}));
+
+const { mockGetBarcodeByValue } = vi.hoisted(() => ({
+  mockGetBarcodeByValue: vi.fn(),
+}));
+// why: the collaborator the fallback delegates to. Mocking it makes "did we
+// even look?" assertable — the add-on-off case must not query.
+vi.mock("~/modules/barcode/service.server", () => ({
+  getBarcodeByValue: mockGetBarcodeByValue,
+}));
+
+const { mockGetQr } = vi.hoisted(() => ({ mockGetQr: vi.fn() }));
+// why: the QR branch, which a SAM-shaped value never reaches. Stubbed so the
+// module cannot fall through to a database.
+vi.mock("~/modules/qr/service.server", () => ({ getQr: mockGetQr }));
+
+import { loader } from "~/routes/api+/get-scanned-item.$qrId";
+
+const ORG_ID = "org-1";
+/** A value that satisfies the SAM id pattern but is stored as a barcode. */
+const SAM_SHAPED = "ZZQ-000123";
+const SAM_NOT_FOUND =
+  "This SAM ID doesn't exist or it doesn't belong to your current organization.";
+/**
+ * The status the SAM error carries.
+ *
+ * `ShelfError` defaults to 500 when no status is given, and this throw gives
+ * none — so a SAM miss answers 500, not 404. `shouldBeCaptured: false` keeps it
+ * out of Sentry, and `resolveAssetIdFromSamId` maps whatever status it gets, so
+ * nothing downstream depends on the number. Asserted as it stands: the fallback
+ * must not move it either way.
+ */
+const SAM_NOT_FOUND_STATUS = 500;
+
+/** An asset row as `ASSET_INCLUDE` returns it, trimmed to the image cascade. */
+function assetRow(id: string) {
+  return {
+    id,
+    title: "An asset",
+    mainImage: null,
+    thumbnailImage: null,
+    assetModel: null,
+  };
+}
+
+/**
+ * Invokes the loader for one scanned value.
+ *
+ * The loader answers with React Router's `data()` wrapper, which carries the
+ * payload and the response init side by side rather than a serialized
+ * `Response` — so the status is read off `init` and the body off `data`. A
+ * success omits `init` entirely, which is the framework's 200.
+ */
+async function scan(value: string) {
+  const result = await loader({
+    request: new Request(
+      `http://localhost/api/get-scanned-item/${encodeURIComponent(value)}`
+    ),
+    params: { qrId: value },
+    context: { getSession: () => ({ userId: "user-1", email: "a@b.c" }) },
+  } as unknown as Parameters<typeof loader>[0]);
+
+  return {
+    status: result.init?.status ?? 200,
+    body: result.data as {
+      error: { message: string } | null;
+      qr?: { type?: string; asset?: { id: string }; kit?: { id: string } };
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default posture: the workspace holds the add-on, so each test only has to
+  // state what it changes.
+  mockRequirePermission.mockResolvedValue({
+    organizationId: ORG_ID,
+    canUseBarcodes: true,
+  });
+});
+
+describe("GET /api/get-scanned-item/:qrId — SAM-shaped barcode fallback", () => {
+  it("resolves an asset-linked barcode when no asset carries that SAM id", async () => {
+    mockAssetFindFirst.mockResolvedValue(null);
+    mockGetBarcodeByValue.mockResolvedValue({
+      asset: assetRow("asset-1"),
+      kit: null,
+    });
+
+    const { status, body } = await scan(SAM_SHAPED);
+
+    expect(status).toBe(200);
+    expect(body.qr?.type).toBe("asset");
+    expect(body.qr?.asset?.id).toBe("asset-1");
+    // The raw scanned string is what reaches the barcode table — the helper
+    // matches original case first, then uppercase — and it stays org-scoped.
+    expect(mockGetBarcodeByValue).toHaveBeenCalledWith(
+      expect.objectContaining({ value: SAM_SHAPED, organizationId: ORG_ID })
+    );
+  });
+
+  it("resolves a kit-linked barcode", async () => {
+    mockAssetFindFirst.mockResolvedValue(null);
+    mockGetBarcodeByValue.mockResolvedValue({
+      asset: null,
+      kit: { id: "kit-1", name: "A kit" },
+    });
+
+    const { status, body } = await scan(SAM_SHAPED);
+
+    expect(status).toBe(200);
+    expect(body.qr?.type).toBe("kit");
+    expect(body.qr?.kit?.id).toBe("kit-1");
+    expect(body.qr?.asset).toBeUndefined();
+  });
+
+  it("keeps the SAM error and never reads the barcode table without the add-on", async () => {
+    // why: the barcode table is add-on data. This endpoint must refuse it on
+    // the same terms as its camera-scan sibling, which reads the same flag.
+    mockRequirePermission.mockResolvedValue({
+      organizationId: ORG_ID,
+      canUseBarcodes: false,
+    });
+    mockAssetFindFirst.mockResolvedValue(null);
+
+    const { status, body } = await scan(SAM_SHAPED);
+
+    expect(status).toBe(SAM_NOT_FOUND_STATUS);
+    expect(body.error?.message).toBe(SAM_NOT_FOUND);
+    expect(mockGetBarcodeByValue).not.toHaveBeenCalled();
+  });
+
+  it("keeps the SAM error when the barcode exists but is linked to nothing", async () => {
+    // why: an unlinked barcode resolves to no item, and the response must not
+    // reveal that a row exists for it.
+    mockAssetFindFirst.mockResolvedValue(null);
+    mockGetBarcodeByValue.mockResolvedValue({ asset: null, kit: null });
+
+    const { status, body } = await scan(SAM_SHAPED);
+
+    expect(status).toBe(SAM_NOT_FOUND_STATUS);
+    expect(body.error?.message).toBe(SAM_NOT_FOUND);
+  });
+
+  it("keeps the SAM error when the workspace holds no such barcode", async () => {
+    mockAssetFindFirst.mockResolvedValue(null);
+    mockGetBarcodeByValue.mockResolvedValue(null);
+
+    const { status, body } = await scan(SAM_SHAPED);
+
+    expect(status).toBe(SAM_NOT_FOUND_STATUS);
+    expect(body.error?.message).toBe(SAM_NOT_FOUND);
+  });
+
+  it("resolves a real SAM id without touching the barcode table", async () => {
+    // why: the SAM id is the core identifier — a value that is both a SAM id
+    // and a barcode resolves as the SAM, and costs no extra query.
+    mockAssetFindFirst.mockResolvedValue(assetRow("asset-9"));
+
+    const { status, body } = await scan(SAM_SHAPED);
+
+    expect(status).toBe(200);
+    expect(body.qr?.type).toBe("asset");
+    expect(body.qr?.asset?.id).toBe("asset-9");
+    expect(mockGetBarcodeByValue).not.toHaveBeenCalled();
+  });
+
+  it("leaves a non-SAM-shaped value on the QR path", async () => {
+    // why: the fallback lives inside the SAM branch only. A plain QR id must
+    // still resolve through `getQr`, untouched.
+    mockGetQr.mockResolvedValue({
+      id: "abcdefghij",
+      organizationId: ORG_ID,
+      assetId: "asset-2",
+      kitId: null,
+      asset: assetRow("asset-2"),
+      kit: null,
+    });
+
+    const { status, body } = await scan("abcdefghij");
+
+    expect(status).toBe(200);
+    expect(body.qr?.type).toBe("asset");
+    expect(body.qr?.asset?.id).toBe("asset-2");
+    expect(mockGetBarcodeByValue).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## The problem

A value matching the SAM ID pattern (letters, hyphen, four or more digits) is
treated as a SAM ID by every scanner path before anything else is tried. A
workspace that prints labels whose barcode value happens to have that shape —
registered as a barcode on the asset, not as the asset's SAM ID — therefore
never reaches barcode resolution at all. The scan asks the SAM resolver, gets a
miss, and dead-ends, even though the workspace holds the code.

Two surfaces have the dead end:

| Surface | Path today | Result |
| --- | --- | --- |
| Companion scanner (camera and manual entry) | SAM-shaped → `/api/mobile/get-scanned-item` or `/api/mobile/qr` | "Lookup Failed" |
| Web scanner mode (keyboard wedge or typed, the default on md+ viewports) | SAM-shaped → `/api/get-scanned-item` | SAM ID not found |
| Web camera scan | carries its symbology → `/api/get-scanned-barcode` | resolves fine |

## The fix

Both SAM branches now fall back to the workspace's own barcode table when no
asset carries that sequential ID.

- **`modules/api/mobile-code-resolve.server.ts`** (commit 1) — the shared mobile
  resolver, so both mobile routes get it. Returns the payload shape the QR path
  returns, with `recordableQrId: null` because a barcode has no QR row to
  attribute a scan to.
- **`routes/api+/get-scanned-item.$qrId.ts`** (commit 2) — the web scanned-item
  route, answering with the shape its own QR branch answers with.

Order is deliberate: the SAM ID is the core identifier and always wins, so a
value that is both resolves as the SAM and costs no extra query. The lookup is
scoped to the caller's own workspace — no sibling-workspace search — and passes
the raw scanned string, so `getBarcodeByValue`'s original-case-then-uppercase
preference still applies. A barcode that exists but is linked to neither an
asset nor a kit falls through to the unchanged SAM error, so the response never
reveals that a row exists for a code that resolves to nothing.

Each side is gated on the Barcodes add-on the way its own app surface already
gates: the mobile resolver uses `canUseBarcodes` from `subscription.server`,
matching `api+/mobile+/barcode.$value.ts`; the web route uses the
`canUseBarcodes` flag `requirePermission` already resolves, matching
`api+/get-scanned-barcode.$value.ts`. The two differ on self-hosted deployments
and that difference predates this PR — keeping each endpoint consistent with its
sibling is what matters for a scan that falls back between them.

The web route also picks up a small extraction: the audit counters, the picker
bound and the image-cascade collapse were duplicated across its two existing
branches and would have landed a third time here. They now live in one
`serializeScannedAsset` helper that all three lookups call, so a scanned asset
carries identical fields whichever one matched.

That extraction is a **pure refactor — the QR branch's output is identical**.
The logic moved verbatim: the same audit lookup under the same
`auditSessionId` guard, the same picker call under the same `pickerContext`
guard, the same `serializeAssetImage` spread. Both guards previously also
tested `asset?.id`, which is now implied because the helper is only ever called
with an asset. No field was added, removed or reordered on either existing
branch.

## Ship

Server deploy, no app update needed. The companion is unchanged, so this reaches
every installed build with the next deploy — no OTA, no store release.

## Test evidence

`pnpm webapp:validate` green: **453 test files, 5973 tests passed**, 0 lint
errors, typecheck clean.

New coverage, six cases per side (mobile in
`mobile-code-resolve.server.test.ts`, web in
`test/routes-tests/api+/get-scanned-item.$qrId.test.ts`):

- SAM-shaped value with no matching asset, add-on on, barcode linked to an asset → resolves, `recordableQrId` null
- same, kit-linked barcode → resolves as a kit
- add-on off → SAM error unchanged, and the barcode table is never queried
- barcode exists but is linked to nothing → SAM error unchanged
- no such barcode → SAM error unchanged
- a real SAM ID still resolves without touching the barcode table

Verified end to end against a real database on a QA workspace: a `Code128`
barcode whose value is SAM-shaped, registered on an asset whose own SAM ID is
different.

```
BEFORE  GET /api/mobile/get-scanned-item/<sam-shaped>?orgId=<org>
HTTP 404
{ "error": { "message": "This SAM ID doesn't exist or it doesn't belong to your current organization." } }

AFTER   GET /api/mobile/get-scanned-item/<sam-shaped>?orgId=<org>
HTTP 200
{ "qr": { "id": "<sam-shaped>", "assetId": "<asset>", "kitId": null,
          "asset": { "sequentialId": "<a different SAM id>", "status": "AVAILABLE" }, "kit": null } }
```

Control, unchanged either side: scanning that asset's real SAM ID returns 200
both before and after. The test row was removed afterwards and its absence
verified.

## Notes and follow-ups

- The web SAM miss answers **500**, not 404 — `ShelfError` defaults to 500 and
  that throw sets no status. Pre-existing and left alone here; the new test
  asserts it as it stands so the fallback cannot move it silently. Worth a
  separate look.
- Barcode values are stored uppercase for `Code128` / `Code39` / `DataMatrix` /
  `EAN13`, but `ExternalQR` keeps its case. A lowercase SAM-shaped `ExternalQR`
  value therefore still will not match, since the SAM pattern only matches after
  uppercasing.
- Follow-up, app side: routing by camera symbology so a `Code128` scan can skip
  the SAM guess entirely. That is an OTA change for a later companion release.
- Follow-up: sibling-workspace search for SAM-shaped barcodes, deliberately out
  of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Scanned SAM-shaped values can now resolve through registered barcodes linked to assets or kits when no matching asset ID exists.
  - Barcode-based resolution is available only when the Barcodes add-on is enabled.
  - Resolved barcode scans include the same asset details and metadata as other scan results.

- **Bug Fixes**
  - Existing not-found behavior is preserved for unavailable, unlinked, or unsupported barcode scans.
  - Direct SAM ID matches continue to resolve without unnecessary barcode lookups.
  - Non-SAM-shaped values continue to use the existing QR-code resolution flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
