### PR TITLE
fix(webapp): set a browser floor and fail old browsers with a message

### DIFF
--- a/.claude/rules/client-ids-via-generate-client-id.md
+++ b/.claude/rules/client-ids-via-generate-client-id.md
@@ -8,8 +8,9 @@ globs: ["apps/webapp/app/**/*.ts", "apps/webapp/app/**/*.tsx"]
 `crypto.randomUUID` is undefined in older browsers and in every insecure
 context (a self-hosted instance on plain HTTP), so a direct call crashes the
 component that renders it. `generateClientId()` in `~/utils/id/client-id`
-returns the same v4 UUID shape on every runtime. ESLint rejects the direct
-call in client code; `*.server.ts` modules run on Node and may keep it.
+returns the same v4 UUID shape on every runtime. ESLint rejects every
+`.randomUUID` access in client code (`crypto.`, `globalThis.crypto.`,
+`window.crypto.`); `*.server.ts` modules run on Node and may keep it.
 
 ```ts
 // ❌ Bad — throws "crypto.randomUUID is not a function" on unsupported runtimes
@@ -20,8 +21,9 @@ import { generateClientId } from "~/utils/id/client-id";
 const key = generateClientId();
 ```
 
-The supported-browser floor is `build.target` in `apps/webapp/vite.config.ts`
-(syntax is lowered to it) plus the runtime probes in
-`app/utils/browser-support.ts` (older browsers get the "browser out of date"
-screen instead of a hang). Before using a browser API newer than that floor,
-add a guard or extend the probes.
+The supported-browser floor (Chrome 98, Edge 98, Firefox 94, Safari 15.4) is
+pinned in two places that must move together: `build.target` in
+`apps/webapp/vite.config.ts` (syntax is lowered to it) and the runtime probes
+in `app/utils/browser-support.ts` (older browsers get the "browser out of
+date" screen instead of a hang). Before using a browser API newer than that
+floor, add a guard or extend the probes.

--- a/.claude/rules/client-ids-via-generate-client-id.md
+++ b/.claude/rules/client-ids-via-generate-client-id.md
@@ -1,0 +1,27 @@
+---
+description: Client code must create unique ids with generateClientId(), never crypto.randomUUID(); the browser floor lives in vite build.target plus the inline check in browser-support.ts
+globs: ["apps/webapp/app/**/*.ts", "apps/webapp/app/**/*.tsx"]
+---
+
+# Client ids via `generateClientId()`
+
+`crypto.randomUUID` is undefined in older browsers and in every insecure
+context (a self-hosted instance on plain HTTP), so a direct call crashes the
+component that renders it. `generateClientId()` in `~/utils/id/client-id`
+returns the same v4 UUID shape on every runtime. ESLint rejects the direct
+call in client code; `*.server.ts` modules run on Node and may keep it.
+
+```ts
+// ❌ Bad — throws "crypto.randomUUID is not a function" on unsupported runtimes
+const key = crypto.randomUUID();
+
+// ✅ Good
+import { generateClientId } from "~/utils/id/client-id";
+const key = generateClientId();
+```
+
+The supported-browser floor is `build.target` in `apps/webapp/vite.config.ts`
+(syntax is lowered to it) plus the runtime probes in
+`app/utils/browser-support.ts` (older browsers get the "browser out of date"
+screen instead of a hang). Before using a browser API newer than that floor,
+add a guard or extend the probes.

--- a/apps/webapp/.eslintrc
+++ b/apps/webapp/.eslintrc
@@ -173,6 +173,22 @@
         "no-console": "off",
         "@typescript-eslint/require-await": "off"
       }
+    },
+    {
+      // Client code runs in browsers and on plain-HTTP self-hosted origins where
+      // `crypto.randomUUID` is undefined; `generateClientId` covers both.
+      "files": ["app/**/*.ts", "app/**/*.tsx"],
+      "excludedFiles": ["app/**/*.server.ts", "app/utils/id/client-id.ts"],
+      "rules": {
+        "no-restricted-properties": [
+          "error",
+          {
+            "object": "crypto",
+            "property": "randomUUID",
+            "message": "Use generateClientId() from ~/utils/id/client-id: crypto.randomUUID is missing in older browsers and in insecure contexts."
+          }
+        ]
+      }
     }
   ]
 }

--- a/apps/webapp/.eslintrc
+++ b/apps/webapp/.eslintrc
@@ -176,15 +176,17 @@
     },
     {
       // Client code runs in browsers and on plain-HTTP self-hosted origins where
-      // `crypto.randomUUID` is undefined; `generateClientId` covers both.
+      // `crypto.randomUUID` is undefined; `generateClientId` covers both. The
+      // selector catches every spelling (`crypto.`, `globalThis.crypto.`,
+      // `window.crypto.`, bracket access), which `no-restricted-properties`
+      // cannot do for nested objects.
       "files": ["app/**/*.ts", "app/**/*.tsx"],
       "excludedFiles": ["app/**/*.server.ts", "app/utils/id/client-id.ts"],
       "rules": {
-        "no-restricted-properties": [
+        "no-restricted-syntax": [
           "error",
           {
-            "object": "crypto",
-            "property": "randomUUID",
+            "selector": "MemberExpression[computed=false][property.name='randomUUID'], MemberExpression[computed=true][property.value='randomUUID']",
             "message": "Use generateClientId() from ~/utils/id/client-id: crypto.randomUUID is missing in older browsers and in insecure contexts."
           }
         ]

--- a/apps/webapp/app/components/assets/assets-index/advanced-filters/value-field.tsx
+++ b/apps/webapp/app/components/assets/assets-index/advanced-filters/value-field.tsx
@@ -42,6 +42,7 @@ import {
   adjustDateToUTC,
   isDateString,
 } from "~/utils/date-fns";
+import { generateClientId } from "~/utils/id/client-id";
 import { handleActivationKeyPress } from "~/utils/keyboard";
 import { tw } from "~/utils/tw";
 import { resolveTeamMemberName } from "~/utils/user";
@@ -59,23 +60,6 @@ function ErrorDisplay({ error }: { error?: string }) {
   return error ? (
     <div className="mt-1 text-sm text-red-500">{error}</div>
   ) : null;
-}
-
-/**
- * Generates a stable unique ID for a MultiDateInput row so React can use
- * it as a map key. `crypto.randomUUID` is preferred when available (modern
- * browsers and node), with a fallback to avoid SSR crashes.
- */
-let dateEntryCounter = 0;
-function createDateEntryId(): string {
-  if (
-    typeof globalThis.crypto !== "undefined" &&
-    typeof globalThis.crypto.randomUUID === "function"
-  ) {
-    return globalThis.crypto.randomUUID();
-  }
-  dateEntryCounter += 1;
-  return `date-entry-${dateEntryCounter}-${Date.now()}`;
 }
 
 /**
@@ -2327,9 +2311,9 @@ function MultiDateInput({
   type DateEntry = { id: string; value: string };
 
   const [dates, setDates] = useState<DateEntry[]>(() => {
-    if (!value) return [{ id: createDateEntryId(), value: "" }];
+    if (!value) return [{ id: generateClientId(), value: "" }];
     return value.split(",").map((d) => ({
-      id: createDateEntryId(),
+      id: generateClientId(),
       value: d.trim(),
     }));
   });
@@ -2353,7 +2337,7 @@ function MultiDateInput({
 
   // Add new date field
   const addDateField = () => {
-    setDates([...dates, { id: createDateEntryId(), value: "" }]);
+    setDates([...dates, { id: generateClientId(), value: "" }]);
   };
   // Remove date field at index
   const removeDateField = (indexToRemove: number) => {

--- a/apps/webapp/app/components/forms/barcodes-input.tsx
+++ b/apps/webapp/app/components/forms/barcodes-input.tsx
@@ -22,6 +22,7 @@ import {
   normalizeBarcodeValue,
 } from "~/modules/barcode/validation";
 import { getValidationErrors } from "~/utils/http";
+import { generateClientId } from "~/utils/id/client-id";
 import { handleActivationKeyPress } from "~/utils/keyboard";
 import { tw } from "~/utils/tw";
 import Input from "./input";
@@ -49,7 +50,7 @@ type BarcodeInputWithKey = BarcodeInput & { clientKey: string };
 
 /** Generate a stable key for a barcode row (persisted id or fresh UUID). */
 const makeBarcodeKey = (existingId?: string): string =>
-  existingId ?? crypto.randomUUID();
+  existingId ?? generateClientId();
 
 type BarcodesInputProps = {
   className?: string;

--- a/apps/webapp/app/components/forms/categories-input.tsx
+++ b/apps/webapp/app/components/forms/categories-input.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { CSSProperties } from "react";
+import { generateClientId } from "~/utils/id/client-id";
 import { tw } from "~/utils/tw";
 import DynamicSelect from "../dynamic-select/dynamic-select";
 import InlineEntityCreationDialog from "../inline-entity-creation-dialog/inline-entity-creation-dialog";
@@ -23,7 +24,7 @@ type CategoriesInputProps = {
 type CategoryRow = { clientKey: string; value: string };
 
 /** Generate a stable key for a new/incoming category row. */
-const makeCategoryKey = (): string => crypto.randomUUID();
+const makeCategoryKey = (): string => generateClientId();
 
 export default function CategoriesInput({
   className,

--- a/apps/webapp/app/components/layout/maintenance-mode.tsx
+++ b/apps/webapp/app/components/layout/maintenance-mode.tsx
@@ -19,10 +19,15 @@ export default function BlockInteractions({
   icon,
 }: Props) {
   return (
-    <div className="fixed z-[9999999] h-dvh w-screen px-4 py-16 md:p-16">
+    // `h-screen` is the fallback for browsers without dynamic viewport units,
+    // so the overlay still covers the page on the ones this screen exists for.
+    <div className="fixed z-[9999999] h-screen w-screen px-4 py-16 supports-[height:100dvh]:h-dvh md:p-16">
       <img
         src="/static/images/bg-overlay1.png"
         alt="background"
+        // Deferred so a hidden instance (the browser-support gate in root.tsx)
+        // does not download the image on every page load.
+        loading="lazy"
         className="absolute left-0 top-0 -z-10 size-full object-cover"
       />
       <div className="flex size-full items-center justify-center bg-white shadow-xl">

--- a/apps/webapp/app/entry.client.tsx
+++ b/apps/webapp/app/entry.client.tsx
@@ -5,6 +5,7 @@ import { Provider as JotaiProvider } from "jotai";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
 
+import { isUnsupportedBrowser } from "~/utils/browser-support";
 import { handleClientBeforeSend } from "~/utils/sentry-filters";
 
 if (window.env?.SENTRY_DSN) {
@@ -61,22 +62,32 @@ if (window.env?.SENTRY_DSN) {
   });
 }
 
-React.startTransition(() => {
-  hydrateRoot(
-    document,
-    <React.StrictMode>
-      <JotaiProvider>
-        <HydratedRouter />
-      </JotaiProvider>
-    </React.StrictMode>,
-    {
-      onRecoverableError(error, errorInfo) {
-        if (window.env?.SENTRY_DSN) {
-          Sentry.captureException(error, {
-            extra: { componentStack: errorInfo.componentStack },
-          });
-        }
-      },
-    }
-  );
-});
+if (isUnsupportedBrowser()) {
+  // The inline check in `root.tsx` flagged a browser that cannot run this
+  // bundle. Leave the server-rendered "browser out of date" screen in place
+  // rather than hydrating an app that would crash behind it, and record the
+  // visit so the size of that audience stays visible.
+  if (window.env?.SENTRY_DSN) {
+    Sentry.captureMessage("Unsupported browser blocked", "info");
+  }
+} else {
+  React.startTransition(() => {
+    hydrateRoot(
+      document,
+      <React.StrictMode>
+        <JotaiProvider>
+          <HydratedRouter />
+        </JotaiProvider>
+      </React.StrictMode>,
+      {
+        onRecoverableError(error, errorInfo) {
+          if (window.env?.SENTRY_DSN) {
+            Sentry.captureException(error, {
+              extra: { componentStack: errorInfo.componentStack },
+            });
+          }
+        },
+      }
+    );
+  });
+}

--- a/apps/webapp/app/hooks/use-tab-id.ts
+++ b/apps/webapp/app/hooks/use-tab-id.ts
@@ -13,6 +13,7 @@
  * @see {@link file://./../utils/tab-id.server.ts} — server-side counterpart
  */
 import { useEffect, useRef } from "react";
+import { generateClientId } from "~/utils/id/client-id";
 
 const SESSION_KEY = "__shelfTabId";
 
@@ -32,7 +33,7 @@ export function useTabId(): string {
     const stored = sessionStorage.getItem(SESSION_KEY);
     // Cloned tabs (window.open / target="_blank") inherit sessionStorage,
     // so generate a fresh ID when an opener is detected.
-    tabIdRef.current = stored && !window.opener ? stored : crypto.randomUUID();
+    tabIdRef.current = stored && !window.opener ? stored : generateClientId();
     sessionStorage.setItem(SESSION_KEY, tabIdRef.current);
   }
 

--- a/apps/webapp/app/root.tsx
+++ b/apps/webapp/app/root.tsx
@@ -33,6 +33,7 @@ import globalStylesheetUrl from "./styles/global.css?url";
 import nProgressCustomStyles from "./styles/nprogress.css?url";
 import pmDocStylesheetUrl from "./styles/pm-doc.css?url";
 import styles from "./tailwind.css?url";
+import { BROWSER_SUPPORT_CHECK_SCRIPT } from "./utils/browser-support";
 import {
   ClientHintCheck,
   detectFormatPrefsForPersistence,
@@ -197,6 +198,14 @@ export function Layout({ children }: { children: ReactNode }) {
             the Shelf Companion App Store listing (id6765639874), or "Open" if
             installed. Apple-hosted, zero-maintenance, no CLS, no cookie. */}
         <meta name="apple-itunes-app" content="app-id=6765639874" />
+        {/* why: a classic inline script runs even in browsers that cannot
+            execute the module bundle, so they get the "browser out of date"
+            screen below instead of a spinner. See `utils/browser-support.ts`. */}
+        <script
+          nonce={nonce}
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: BROWSER_SUPPORT_CHECK_SCRIPT }}
+        />
         <ClientHintCheck nonce={nonce} />
         <style data-fullcalendar />
         <Meta />
@@ -204,6 +213,16 @@ export function Layout({ children }: { children: ReactNode }) {
         <Clarity />
       </head>
       <body suppressHydrationWarning>
+        {/* Revealed by `html[data-unsupported-browser]` (global.css) when the
+            inline check in <head> flags the browser; hydration is skipped then. */}
+        <div id="unsupported-browser" hidden>
+          <BlockInteractions
+            title="Your browser is out of date"
+            content="Shelf needs a current browser. Please update your browser, or switch to the latest Chrome, Firefox, Edge or Safari."
+            icon="x"
+          />
+        </div>
+
         <noscript>
           <BlockInteractions
             title="JavaScript is disabled"

--- a/apps/webapp/app/root.tsx
+++ b/apps/webapp/app/root.tsx
@@ -33,7 +33,11 @@ import globalStylesheetUrl from "./styles/global.css?url";
 import nProgressCustomStyles from "./styles/nprogress.css?url";
 import pmDocStylesheetUrl from "./styles/pm-doc.css?url";
 import styles from "./tailwind.css?url";
-import { BROWSER_SUPPORT_CHECK_SCRIPT } from "./utils/browser-support";
+import {
+  BROWSER_SUPPORT_CHECK_SCRIPT,
+  BROWSER_SUPPORT_GATE_STYLES,
+  UNSUPPORTED_BROWSER_SCREEN_ID,
+} from "./utils/browser-support";
 import {
   ClientHintCheck,
   detectFormatPrefsForPersistence,
@@ -200,7 +204,10 @@ export function Layout({ children }: { children: ReactNode }) {
         <meta name="apple-itunes-app" content="app-id=6765639874" />
         {/* why: a classic inline script runs even in browsers that cannot
             execute the module bundle, so they get the "browser out of date"
-            screen below instead of a spinner. See `utils/browser-support.ts`. */}
+            screen below instead of a spinner. The inline style keeps that
+            screen hidden until the script flags the document, without relying
+            on a linked stylesheet. See `utils/browser-support.ts`. */}
+        <style nonce={nonce}>{BROWSER_SUPPORT_GATE_STYLES}</style>
         <script
           nonce={nonce}
           // eslint-disable-next-line react/no-danger
@@ -213,9 +220,9 @@ export function Layout({ children }: { children: ReactNode }) {
         <Clarity />
       </head>
       <body suppressHydrationWarning>
-        {/* Revealed by `html[data-unsupported-browser]` (global.css) when the
-            inline check in <head> flags the browser; hydration is skipped then. */}
-        <div id="unsupported-browser" hidden>
+        {/* Hidden by the inline gate styles in <head> and revealed when the
+            inline check there flags the browser; hydration is skipped then. */}
+        <div id={UNSUPPORTED_BROWSER_SCREEN_ID}>
           <BlockInteractions
             title="Your browser is out of date"
             content="Shelf needs a current browser. Please update your browser, or switch to the latest Chrome, Firefox, Edge or Safari."

--- a/apps/webapp/app/styles/global.css
+++ b/apps/webapp/app/styles/global.css
@@ -340,3 +340,10 @@ div[data-radix-popper-content-wrapper] > div[data-side="bottom"] {
 .pseudo-border-bottom {
   @apply after:absolute after:inset-x-0 after:bottom-0 after:border-b after:border-gray-200 after:content-[''] hover:bg-gray-100;
 }
+
+/* Browser-support gate: the inline check in app/root.tsx sets this attribute
+   on <html> when the browser cannot run the client bundle. Revealing the
+   screen through CSS keeps the gate working before any module script runs. */
+html[data-unsupported-browser] #unsupported-browser {
+  display: block;
+}

--- a/apps/webapp/app/styles/global.css
+++ b/apps/webapp/app/styles/global.css
@@ -340,10 +340,3 @@ div[data-radix-popper-content-wrapper] > div[data-side="bottom"] {
 .pseudo-border-bottom {
   @apply after:absolute after:inset-x-0 after:bottom-0 after:border-b after:border-gray-200 after:content-[''] hover:bg-gray-100;
 }
-
-/* Browser-support gate: the inline check in app/root.tsx sets this attribute
-   on <html> when the browser cannot run the client bundle. Revealing the
-   screen through CSS keeps the gate working before any module script runs. */
-html[data-unsupported-browser] #unsupported-browser {
-  display: block;
-}

--- a/apps/webapp/app/utils/browser-support.test.ts
+++ b/apps/webapp/app/utils/browser-support.test.ts
@@ -10,8 +10,10 @@
 import { describe, expect, it } from "vitest";
 import {
   BROWSER_SUPPORT_CHECK_SCRIPT,
+  BROWSER_SUPPORT_GATE_STYLES,
   isUnsupportedBrowser,
   UNSUPPORTED_BROWSER_ATTRIBUTE,
+  UNSUPPORTED_BROWSER_SCREEN_ID,
 } from "./browser-support";
 
 type Probes = {
@@ -28,6 +30,10 @@ const MODERN: Required<Probes> = {
 
 /** Runs the inline script against a fake document and returns the html attributes it set. */
 function runCheck(overrides: Probes = {}) {
+  // why: the script reads `document`, `Object`, `structuredClone` and `Array`
+  // as free globals. Passing fakes as function parameters shadows the real
+  // ones, so each probe can be removed on its own without touching the
+  // test runtime's globals.
   const probes = { ...MODERN, ...overrides };
   const attributes = new Map<string, string>();
   const fakeDocument = {
@@ -77,6 +83,17 @@ describe("BROWSER_SUPPORT_CHECK_SCRIPT", () => {
 
   it("stays parseable by pre-ES2015 engines (no arrow functions, let/const, template literals)", () => {
     expect(BROWSER_SUPPORT_CHECK_SCRIPT).not.toMatch(/=>|\blet\b|\bconst\b|`/);
+  });
+});
+
+describe("BROWSER_SUPPORT_GATE_STYLES", () => {
+  it("hides the screen by default and reveals it for the flagged document", () => {
+    expect(BROWSER_SUPPORT_GATE_STYLES).toContain(
+      `#${UNSUPPORTED_BROWSER_SCREEN_ID}{display:none}`
+    );
+    expect(BROWSER_SUPPORT_GATE_STYLES).toContain(
+      `html[${UNSUPPORTED_BROWSER_ATTRIBUTE}] #${UNSUPPORTED_BROWSER_SCREEN_ID}{display:block}`
+    );
   });
 });
 

--- a/apps/webapp/app/utils/browser-support.test.ts
+++ b/apps/webapp/app/utils/browser-support.test.ts
@@ -95,6 +95,12 @@ describe("BROWSER_SUPPORT_GATE_STYLES", () => {
       `html[${UNSUPPORTED_BROWSER_ATTRIBUTE}] #${UNSUPPORTED_BROWSER_SCREEN_ID}{display:block}`
     );
   });
+
+  it("removes the rest of the body from rendering while the document is flagged", () => {
+    expect(BROWSER_SUPPORT_GATE_STYLES).toContain(
+      `html[${UNSUPPORTED_BROWSER_ATTRIBUTE}] body>:not(#${UNSUPPORTED_BROWSER_SCREEN_ID}){display:none}`
+    );
+  });
 });
 
 describe("isUnsupportedBrowser", () => {

--- a/apps/webapp/app/utils/browser-support.test.ts
+++ b/apps/webapp/app/utils/browser-support.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for the inline browser-support check.
+ *
+ * The script string is evaluated with shadowed globals so each probe can be
+ * removed independently. It must stay plain ES5: it is the one piece of code
+ * that has to parse in browsers the bundle itself no longer targets.
+ *
+ * @see {@link file://./browser-support.ts}
+ */
+import { describe, expect, it } from "vitest";
+import {
+  BROWSER_SUPPORT_CHECK_SCRIPT,
+  isUnsupportedBrowser,
+  UNSUPPORTED_BROWSER_ATTRIBUTE,
+} from "./browser-support";
+
+type Probes = {
+  hasOwn?: unknown;
+  structuredClone?: unknown;
+  at?: unknown;
+};
+
+const MODERN: Required<Probes> = {
+  hasOwn: () => true,
+  structuredClone: () => undefined,
+  at: () => undefined,
+};
+
+/** Runs the inline script against a fake document and returns the html attributes it set. */
+function runCheck(overrides: Probes = {}) {
+  const probes = { ...MODERN, ...overrides };
+  const attributes = new Map<string, string>();
+  const fakeDocument = {
+    documentElement: {
+      setAttribute: (name: string, value: string) =>
+        attributes.set(name, value),
+    },
+  };
+
+  new Function(
+    "document",
+    "Object",
+    "structuredClone",
+    "Array",
+    BROWSER_SUPPORT_CHECK_SCRIPT
+  )(fakeDocument, { hasOwn: probes.hasOwn }, probes.structuredClone, {
+    prototype: { at: probes.at },
+  });
+
+  return attributes;
+}
+
+describe("BROWSER_SUPPORT_CHECK_SCRIPT", () => {
+  it("leaves a current browser untouched", () => {
+    expect(runCheck().has(UNSUPPORTED_BROWSER_ATTRIBUTE)).toBe(false);
+  });
+
+  it("flags a browser without Object.hasOwn", () => {
+    expect(
+      runCheck({ hasOwn: undefined }).has(UNSUPPORTED_BROWSER_ATTRIBUTE)
+    ).toBe(true);
+  });
+
+  it("flags a browser without structuredClone", () => {
+    expect(
+      runCheck({ structuredClone: undefined }).has(
+        UNSUPPORTED_BROWSER_ATTRIBUTE
+      )
+    ).toBe(true);
+  });
+
+  it("flags a browser without Array.prototype.at", () => {
+    expect(runCheck({ at: undefined }).has(UNSUPPORTED_BROWSER_ATTRIBUTE)).toBe(
+      true
+    );
+  });
+
+  it("stays parseable by pre-ES2015 engines (no arrow functions, let/const, template literals)", () => {
+    expect(BROWSER_SUPPORT_CHECK_SCRIPT).not.toMatch(/=>|\blet\b|\bconst\b|`/);
+  });
+});
+
+describe("isUnsupportedBrowser", () => {
+  it("mirrors the attribute on the document element", () => {
+    document.documentElement.removeAttribute(UNSUPPORTED_BROWSER_ATTRIBUTE);
+    expect(isUnsupportedBrowser()).toBe(false);
+
+    document.documentElement.setAttribute(UNSUPPORTED_BROWSER_ATTRIBUTE, "");
+    expect(isUnsupportedBrowser()).toBe(true);
+
+    document.documentElement.removeAttribute(UNSUPPORTED_BROWSER_ATTRIBUTE);
+  });
+});

--- a/apps/webapp/app/utils/browser-support.ts
+++ b/apps/webapp/app/utils/browser-support.ts
@@ -1,0 +1,40 @@
+/**
+ * Detects browsers that cannot run the client bundle and marks the document
+ * so the app fails with an explicit message instead of a spinner that never
+ * resolves.
+ *
+ * The bundle is compiled for Vite's "baseline widely available" browser set
+ * (see `build.target` in `vite.config.ts`), so older browsers parse it but
+ * lack some runtime APIs the bundle calls without guards. The check below runs
+ * as a classic inline script in the document `<head>`, written in ES5 so that
+ * every browser can parse it, before any module script executes. It probes
+ * `Object.hasOwn`, `structuredClone` and `Array.prototype.at`, all available
+ * from Chrome 98, Firefox 94 and Safari 15.4 onwards. The probe is
+ * deliberately narrower than the build target: it blocks only browsers known
+ * to fail at runtime.
+ *
+ * `crypto.randomUUID` is deliberately not probed: it is undefined in insecure
+ * contexts (plain-HTTP self-hosted instances) even in current browsers, and
+ * client code goes through `generateClientId` instead.
+ *
+ * When a probe fails, {@link UNSUPPORTED_BROWSER_ATTRIBUTE} is set on `<html>`.
+ * That attribute reveals the "browser out of date" screen rendered by
+ * `app/root.tsx` (rule in `app/styles/global.css`) and tells
+ * `entry.client.tsx`, via {@link isUnsupportedBrowser}, to skip hydration.
+ */
+export const UNSUPPORTED_BROWSER_ATTRIBUTE = "data-unsupported-browser";
+
+export const BROWSER_SUPPORT_CHECK_SCRIPT = `(function () {
+  var supported =
+    typeof Object.hasOwn === "function" &&
+    typeof structuredClone === "function" &&
+    typeof Array.prototype.at === "function";
+  if (!supported) {
+    document.documentElement.setAttribute("${UNSUPPORTED_BROWSER_ATTRIBUTE}", "");
+  }
+})();`;
+
+/** Whether the inline check flagged the current browser as unsupported. */
+export function isUnsupportedBrowser(): boolean {
+  return document.documentElement.hasAttribute(UNSUPPORTED_BROWSER_ATTRIBUTE);
+}

--- a/apps/webapp/app/utils/browser-support.ts
+++ b/apps/webapp/app/utils/browser-support.ts
@@ -19,10 +19,11 @@
  *
  * When a probe fails, {@link UNSUPPORTED_BROWSER_ATTRIBUTE} is set on `<html>`.
  * {@link BROWSER_SUPPORT_GATE_STYLES}, inlined in the same `<head>`, keeps the
- * "browser out of date" screen (`app/root.tsx`) hidden by default and reveals
- * it for that attribute, and `entry.client.tsx` skips hydration via
- * {@link isUnsupportedBrowser}. The screen carries no `hidden` attribute, so
- * once revealed it is exposed to assistive technology like any other content.
+ * "browser out of date" screen (`app/root.tsx`) hidden by default, reveals it
+ * for that attribute and hides the rest of the body, and `entry.client.tsx`
+ * skips hydration via {@link isUnsupportedBrowser}. The screen carries no
+ * `hidden` attribute, so once revealed it is the only content exposed to
+ * assistive technology.
  */
 export const UNSUPPORTED_BROWSER_ATTRIBUTE = "data-unsupported-browser";
 
@@ -33,8 +34,16 @@ export const UNSUPPORTED_BROWSER_SCREEN_ID = "unsupported-browser";
  * Inline stylesheet for the gate. Lives in `<head>` next to the check script
  * rather than in a linked stylesheet, so the default hidden state applies
  * before any external resource loads.
+ *
+ * While the document is flagged, every other child of `<body>` is removed
+ * from rendering as well, so the server-rendered app behind the screen is
+ * neither focusable nor announced by assistive technology.
  */
-export const BROWSER_SUPPORT_GATE_STYLES = `#${UNSUPPORTED_BROWSER_SCREEN_ID}{display:none}html[${UNSUPPORTED_BROWSER_ATTRIBUTE}] #${UNSUPPORTED_BROWSER_SCREEN_ID}{display:block}`;
+export const BROWSER_SUPPORT_GATE_STYLES = [
+  `#${UNSUPPORTED_BROWSER_SCREEN_ID}{display:none}`,
+  `html[${UNSUPPORTED_BROWSER_ATTRIBUTE}] #${UNSUPPORTED_BROWSER_SCREEN_ID}{display:block}`,
+  `html[${UNSUPPORTED_BROWSER_ATTRIBUTE}] body>:not(#${UNSUPPORTED_BROWSER_SCREEN_ID}){display:none}`,
+].join("");
 
 export const BROWSER_SUPPORT_CHECK_SCRIPT = `(function () {
   var supported =

--- a/apps/webapp/app/utils/browser-support.ts
+++ b/apps/webapp/app/utils/browser-support.ts
@@ -3,26 +3,38 @@
  * so the app fails with an explicit message instead of a spinner that never
  * resolves.
  *
- * The bundle is compiled for Vite's "baseline widely available" browser set
- * (see `build.target` in `vite.config.ts`), so older browsers parse it but
- * lack some runtime APIs the bundle calls without guards. The check below runs
- * as a classic inline script in the document `<head>`, written in ES5 so that
- * every browser can parse it, before any module script executes. It probes
- * `Object.hasOwn`, `structuredClone` and `Array.prototype.at`, all available
- * from Chrome 98, Firefox 94 and Safari 15.4 onwards. The probe is
- * deliberately narrower than the build target: it blocks only browsers known
- * to fail at runtime.
+ * The supported floor is Chrome 98, Edge 98, Firefox 94 and Safari 15.4. The
+ * client bundle is compiled for exactly that set (`build.target` in
+ * `vite.config.ts`), so newer syntax is lowered and a browser below the floor
+ * fails only on runtime APIs the bundle calls without guards. The check below
+ * runs as a classic inline script in the document `<head>`, written in ES5 so
+ * that every browser can parse it, before any module script executes. It
+ * probes `Object.hasOwn`, `structuredClone` and `Array.prototype.at`, which
+ * all arrive together at that floor. Change the floor here and in
+ * `vite.config.ts` together.
  *
  * `crypto.randomUUID` is deliberately not probed: it is undefined in insecure
  * contexts (plain-HTTP self-hosted instances) even in current browsers, and
  * client code goes through `generateClientId` instead.
  *
  * When a probe fails, {@link UNSUPPORTED_BROWSER_ATTRIBUTE} is set on `<html>`.
- * That attribute reveals the "browser out of date" screen rendered by
- * `app/root.tsx` (rule in `app/styles/global.css`) and tells
- * `entry.client.tsx`, via {@link isUnsupportedBrowser}, to skip hydration.
+ * {@link BROWSER_SUPPORT_GATE_STYLES}, inlined in the same `<head>`, keeps the
+ * "browser out of date" screen (`app/root.tsx`) hidden by default and reveals
+ * it for that attribute, and `entry.client.tsx` skips hydration via
+ * {@link isUnsupportedBrowser}. The screen carries no `hidden` attribute, so
+ * once revealed it is exposed to assistive technology like any other content.
  */
 export const UNSUPPORTED_BROWSER_ATTRIBUTE = "data-unsupported-browser";
+
+/** `id` of the "browser out of date" screen rendered by `app/root.tsx`. */
+export const UNSUPPORTED_BROWSER_SCREEN_ID = "unsupported-browser";
+
+/**
+ * Inline stylesheet for the gate. Lives in `<head>` next to the check script
+ * rather than in a linked stylesheet, so the default hidden state applies
+ * before any external resource loads.
+ */
+export const BROWSER_SUPPORT_GATE_STYLES = `#${UNSUPPORTED_BROWSER_SCREEN_ID}{display:none}html[${UNSUPPORTED_BROWSER_ATTRIBUTE}] #${UNSUPPORTED_BROWSER_SCREEN_ID}{display:block}`;
 
 export const BROWSER_SUPPORT_CHECK_SCRIPT = `(function () {
   var supported =

--- a/apps/webapp/app/utils/id/client-id.test.ts
+++ b/apps/webapp/app/utils/id/client-id.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for {@link generateClientId}.
+ *
+ * The helper must return a canonical version 4 UUID on every path: the native
+ * `crypto.randomUUID`, the `getRandomValues` fallback (older browsers and
+ * plain-HTTP origins, where `randomUUID` is undefined), and the `Math.random`
+ * fallback when no `crypto` object exists at all.
+ *
+ * @see {@link file://./client-id.ts}
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { generateClientId } from "./client-id";
+
+const UUID_V4 =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("generateClientId", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses crypto.randomUUID when the runtime provides it", () => {
+    const randomUUID = vi.fn(() => "11111111-2222-4333-8444-555555555555");
+    vi.stubGlobal("crypto", { randomUUID, getRandomValues: vi.fn() });
+
+    expect(generateClientId()).toBe("11111111-2222-4333-8444-555555555555");
+    expect(randomUUID).toHaveBeenCalledOnce();
+  });
+
+  it("builds a v4 UUID from getRandomValues when randomUUID is missing", () => {
+    const getRandomValues = vi.fn((bytes: Uint8Array) => {
+      for (let i = 0; i < bytes.length; i++) bytes[i] = 0xff;
+      return bytes;
+    });
+    vi.stubGlobal("crypto", { getRandomValues });
+
+    const id = generateClientId();
+
+    expect(id).toMatch(UUID_V4);
+    expect(getRandomValues).toHaveBeenCalledOnce();
+    // Version and variant bits are forced even on all-ones input.
+    expect(id).toBe("ffffffff-ffff-4fff-bfff-ffffffffffff");
+  });
+
+  it("still returns a v4 UUID without any crypto object", () => {
+    vi.stubGlobal("crypto", undefined);
+
+    expect(generateClientId()).toMatch(UUID_V4);
+  });
+
+  it("returns distinct ids on consecutive calls", () => {
+    vi.stubGlobal("crypto", undefined);
+
+    const ids = new Set(Array.from({ length: 50 }, () => generateClientId()));
+
+    expect(ids.size).toBe(50);
+  });
+});

--- a/apps/webapp/app/utils/id/client-id.test.ts
+++ b/apps/webapp/app/utils/id/client-id.test.ts
@@ -20,6 +20,8 @@ describe("generateClientId", () => {
   });
 
   it("uses crypto.randomUUID when the runtime provides it", () => {
+    // why: the native call must be observable (called once, value passed
+    // through), which the real Web Crypto object cannot show.
     const randomUUID = vi.fn(() => "11111111-2222-4333-8444-555555555555");
     vi.stubGlobal("crypto", { randomUUID, getRandomValues: vi.fn() });
 
@@ -28,6 +30,9 @@ describe("generateClientId", () => {
   });
 
   it("builds a v4 UUID from getRandomValues when randomUUID is missing", () => {
+    // why: models a browser (or plain-HTTP origin) that has Web Crypto but no
+    // `randomUUID`, with deterministic bytes so the version/variant bit
+    // forcing can be asserted exactly.
     const getRandomValues = vi.fn((bytes: Uint8Array) => {
       for (let i = 0; i < bytes.length; i++) bytes[i] = 0xff;
       return bytes;
@@ -43,12 +48,16 @@ describe("generateClientId", () => {
   });
 
   it("still returns a v4 UUID without any crypto object", () => {
+    // why: models a runtime with no `crypto` global at all, which is the
+    // `Math.random` fallback path.
     vi.stubGlobal("crypto", undefined);
 
     expect(generateClientId()).toMatch(UUID_V4);
   });
 
   it("returns distinct ids on consecutive calls", () => {
+    // why: uniqueness matters most on the weakest (`Math.random`) path, so the
+    // test removes `crypto` to force it.
     vi.stubGlobal("crypto", undefined);
 
     const ids = new Set(Array.from({ length: 50 }, () => generateClientId()));

--- a/apps/webapp/app/utils/id/client-id.ts
+++ b/apps/webapp/app/utils/id/client-id.ts
@@ -1,0 +1,43 @@
+/**
+ * Generates a unique id for client-side bookkeeping: React keys for rows the
+ * user adds to a form, the per-tab id sent to the server, and similar values
+ * that only need to be unique within one browser session.
+ *
+ * `crypto.randomUUID` is the preferred source, but it exists only in current
+ * browsers and only in secure contexts (HTTPS or localhost). An older browser,
+ * or a self-hosted instance served over plain HTTP, has no such function, so
+ * the fallback builds a version 4 UUID from `crypto.getRandomValues`, and from
+ * `Math.random` when no `crypto` object exists at all. Every path returns the
+ * same canonical UUID shape, so callers can rely on the format.
+ *
+ * Never call `crypto.randomUUID` directly from client code; go through this
+ * helper (enforced by the `no-restricted-properties` lint rule).
+ */
+export function generateClientId(): string {
+  const cryptoObject = globalThis.crypto as Crypto | undefined;
+  if (cryptoObject && typeof cryptoObject.randomUUID === "function") {
+    return cryptoObject.randomUUID();
+  }
+
+  const bytes = new Uint8Array(16);
+  if (cryptoObject && typeof cryptoObject.getRandomValues === "function") {
+    cryptoObject.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = Math.floor(Math.random() * 256);
+    }
+  }
+
+  // RFC 4122 layout: version nibble 4, variant bits 10xx.
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (byte) =>
+    byte.toString(16).padStart(2, "0")
+  ).join("");
+
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(
+    12,
+    16
+  )}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -110,7 +110,12 @@ export default defineConfig({
     include: ["./app/routes/**/*.tsx", "./app/routes/**/*.ts"],
   },
   build: {
-    target: "ES2022",
+    // Browser floor for the client bundle: Vite's Baseline "widely available"
+    // set (Chrome 107, Edge 107, Firefox 104, Safari 16). Newer syntax is
+    // lowered at build time, so an older browser fails only on missing runtime
+    // APIs, which the inline check in `app/utils/browser-support.ts` turns
+    // into an explicit message. Raise this floor only together with that check.
+    target: "baseline-widely-available",
     assetsDir: `file-assets`,
     rollupOptions: {
       output: {

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -110,12 +110,13 @@ export default defineConfig({
     include: ["./app/routes/**/*.tsx", "./app/routes/**/*.ts"],
   },
   build: {
-    // Browser floor for the client bundle: Vite's Baseline "widely available"
-    // set (Chrome 107, Edge 107, Firefox 104, Safari 16). Newer syntax is
-    // lowered at build time, so an older browser fails only on missing runtime
-    // APIs, which the inline check in `app/utils/browser-support.ts` turns
-    // into an explicit message. Raise this floor only together with that check.
-    target: "baseline-widely-available",
+    // Browser floor for the client bundle. Pinned explicitly (not a Vite alias
+    // such as "baseline-widely-available", which moves between releases) and
+    // equal to the runtime floor probed by `app/utils/browser-support.ts`:
+    // syntax newer than this set is lowered at build time, so a browser below
+    // the floor fails only on the missing runtime APIs that check detects and
+    // turns into an explicit message. Change the two together.
+    target: ["chrome98", "edge98", "firefox94", "safari15.4"],
     assetsDir: `file-assets`,
     rollupOptions: {
       output: {


### PR DESCRIPTION
## Summary

Older browsers currently fail in two silent ways, both reported from a Safari 14 / macOS Catalina setup:

1. **The assets index never boots.** The client bundle is compiled with `build.target: "ES2022"`, so esbuild leaves class static blocks in place (the Markdoc chunk carries them). Safari before 16.4 throws a `SyntaxError` while parsing that module, the module graph never executes, and the server-rendered "Activating workspace..." spinner from `_layout.tsx` stays on screen forever.
2. **Every logged-in page crashes on Safari before 15.4** with `crypto.randomUUID is not a function`. `useTabId` (mounted by the `Toaster` in `_layout.tsx`) calls `crypto.randomUUID()` unguarded during render. The same call sits in `barcodes-input.tsx` and `categories-input.tsx`. `crypto.randomUUID` is also undefined in insecure contexts, so a self-hosted instance served over plain HTTP hits the same crash in every browser.

This PR pins an explicit browser floor (Chrome 98, Edge 98, Firefox 94, Safari 15.4: the versions where `Object.hasOwn`, `structuredClone` and `Array.prototype.at` all exist) and makes anything below it fail with a message instead of a hang.

## Changes

- **`vite.config.ts`**: `build.target` moves from `"ES2022"` to the explicit array `["chrome98", "edge98", "firefox94", "safari15.4"]`, the same floor the runtime probes check, so syntax can never be the failure mode for a browser the gate lets through. Pinned rather than a Vite alias because aliases move between releases. Newer syntax is lowered at build time; the built client output contains zero class static blocks (verified by scanning all 686 chunks).
- **`utils/id/client-id.ts`** (new): `generateClientId()` prefers `crypto.randomUUID`, falls back to a v4 UUID built from `crypto.getRandomValues`, and finally to `Math.random`. Same canonical shape on every path. `use-tab-id.ts`, `barcodes-input.tsx`, `categories-input.tsx` and the advanced-filter `value-field.tsx` (which had its own local fallback) now go through it. Unit-tested on all three paths.
- **ESLint**: a `no-restricted-syntax` selector rejects every `.randomUUID` member access in `app/**` client code (`crypto.`, `globalThis.crypto.`, `window.crypto.`, bracket access); `*.server.ts` and the helper itself are excluded. Repo rule added in `.claude/rules/client-ids-via-generate-client-id.md`.
- **`utils/browser-support.ts`** (new): a plain-ES5 inline script rendered in the document `<head>` by `root.tsx`. It probes `Object.hasOwn`, `structuredClone` and `Array.prototype.at` and, when one is missing, sets `data-unsupported-browser` on `<html>`. An inline `<style>` next to it keeps the screen hidden by default, reveals it for that attribute and removes every other `<body>` child from rendering while flagged, so no linked stylesheet or `hidden` attribute is involved, the revealed screen is ordinary content for assistive technology, and nothing behind it is focusable or announced. `crypto.randomUUID` is deliberately not probed because of the insecure-context case. Unit-tested with each probe removed, plus guards that the script stays ES5 and that the gate styles hide/reveal the screen.
- **`root.tsx`**: renders the `BlockInteractions` screen ("Your browser is out of date") gated by those inline styles. It lives in `Layout`, so it also covers the error-boundary render.
- **`entry.client.tsx`**: skips `hydrateRoot` when the browser is flagged, so the message is not replaced by an app that would crash behind it, and records one `info` Sentry message per blocked visit so the size of that audience is measurable.
- **`maintenance-mode.tsx`**: the overlay falls back to `h-screen` where `100dvh` is unsupported (that is exactly the audience of the new screen), and lazy-loads its 340 KB background image so the hidden instance does not download it on every page load.

## Verification

- `pnpm webapp:validate` green (tests, lint, typecheck).
- Production build scanned: no `static {` blocks and no unguarded `crypto.randomUUID(` in any client chunk; the `@supports (height:100dvh)` fallback rule is emitted.
- ESLint guard proven: a probe file with a direct `crypto.randomUUID()` call fails lint; `*.server.ts` files still pass.
- Dev server in the browser: a current browser is not flagged and the overlay stays `display: none` (no `hidden` attribute). Deleting `Object.hasOwn` and re-running the inline script flags the document and shows the full-viewport message, checked at desktop and 375px widths. The lazy overlay image is not fetched while hidden and loads once revealed.
- Not verified on a real Safari 14/15 (none available). The mechanism is deterministic: parse-level syntax is now lowered to the target, and the runtime gate is exercised by the tests above.

## Notes

- No migration, no env change.
- After this ships, Safari 15.4+ works again (Catalina tops out at Safari 15.6.1). Safari 15.3 and older, Chrome below 98 and Firefox below 94 get the explicit screen instead of a hang.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a shared client-side ID generator with fallbacks for broader browser compatibility.
  - Added an early browser compatibility check that displays an “out of date browser” message and prevents app startup when required features are unavailable.
  - Improved maintenance-mode layout behavior across viewport sizes and deferred hidden background images.

- **Bug Fixes**
  - Updated client-generated identifiers across forms, filters, and tabs for older or restricted browser environments.
  - Improved compatibility by removing unsupported regular expression syntax.

- **Documentation**
  - Documented supported browser versions and client-side ID generation guidelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->