### PR TITLE
fix(kits): resolve a booking's kits from its slices, not asset membership

### DIFF
--- a/apps/webapp/app/modules/booking/checkout-attribution.ts
+++ b/apps/webapp/app/modules/booking/checkout-attribution.ts
@@ -237,8 +237,9 @@ export function attributeDispositionsByBookingAsset(args: {
  * while a sibling is counted past what it booked.
  *
  * A slice missing from `committedRemainingBySlice` falls back to its booked
- * quantity. The map covers tagged and untagged-resolved `QUANTITY_TRACKED`
- * slices only, so defaulting to zero would starve every `INDIVIDUAL` slice.
+ * quantity. Callers seed the map for the slices they know a claim can reach,
+ * and defaulting an absent one to zero would starve it — the fallback is what
+ * lets a slice the caller never measured still take its share.
  *
  * Pure derivation — no DB calls.
  *

--- a/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
@@ -1,5 +1,10 @@
 import Markdoc from "@markdoc/markdoc";
-import { BookingStatus, AssetStatus, AssetType } from "@prisma/client";
+import {
+  BookingStatus,
+  AssetStatus,
+  AssetType,
+  KitStatus,
+} from "@prisma/client";
 import { CheckoutIntentEnum } from "~/components/booking/checkout-dialog";
 
 import { db } from "~/database/db.server";
@@ -140,9 +145,8 @@ vitest.mock("~/database/db.server", () => {
       // override per-describe `beforeEach` to model bigger slices.
       // why: a kit-driven slice written before `sourceKitId` existed names its
       // kit through this hop (`getKitIdsToAcquireBySlice`). These fixtures set
-      // `assetKitId` with no `sourceKitId`, so the lookup runs; no rows means
-      // the slice resolves to no kit, which is what the note assertions here
-      // expect — kit STATUS is covered in `service.server.test.ts`.
+      // `assetKitId` with no `sourceKitId`, so the lookup runs. The per-test
+      // default is re-installed in `beforeEach`.
       assetKit: {
         findMany: vitest.fn().mockResolvedValue([]),
       },
@@ -443,6 +447,11 @@ describe("partialCheckoutBooking", () => {
             : []
         );
       }
+    );
+    // why: same reasoning as `asset.findMany` above. Default to "no membership
+    // rows resolve", so a slice's kit is named only by the tests that model one.
+    (db.assetKit.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue(
+      []
     );
     // why: same reasoning as `asset.findMany` above — a prior test's
     // `mockResolvedValue({ count: 0 })` (the concurrent-takeover case) would
@@ -1655,6 +1664,64 @@ describe("partialCheckoutBooking - quantity-tracked dispositions", () => {
         unitOfMeasure: "boxes",
         quantity: 122,
       });
+    });
+
+    it("does not check out a kit when only the asset's free-pool slice left", async () => {
+      expect.assertions(1);
+      // Gloves holds two slices on this booking: 22 boxes standalone and 100
+      // inside Kittington. Sending the standalone units out takes none of the
+      // kit's, so the kit is still on the shelf — and the asset id alone cannot
+      // say that, because both slices carry it.
+      (
+        db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+      ).mockResolvedValue(makeGlovesBooking());
+      // why: models the legacy provenance hop resolving Kittington's membership
+      // row, so the kit-driven slice is actually attributed to a kit.
+      (db.assetKit.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
+        { id: "ak-kittington", kitId: "kit-kittington" },
+      ]);
+
+      await partialCheckoutBooking({
+        ...baseParams,
+        checkouts: [
+          {
+            assetId: "asset-gloves",
+            bookingAssetId: "ba-standalone",
+            quantity: 22,
+          },
+        ],
+      });
+
+      expect(db.kit.updateMany).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { status: KitStatus.CHECKED_OUT },
+        })
+      );
+    });
+
+    it("checks out the kit once its own slice has wholly left", async () => {
+      expect.assertions(1);
+      (
+        db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+      ).mockResolvedValue(makeGlovesBooking());
+      (db.assetKit.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
+        { id: "ak-kittington", kitId: "kit-kittington" },
+      ]);
+
+      // All 100 boxes of the kit-driven slice.
+      await partialCheckoutBooking({
+        ...baseParams,
+        checkouts: [
+          { assetId: "asset-gloves", bookingAssetId: "ba-kit", quantity: 100 },
+        ],
+      });
+
+      expect(db.kit.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: { in: ["kit-kittington"] } }),
+          data: { status: KitStatus.CHECKED_OUT },
+        })
+      );
     });
 
     it("names a standalone qty slice per-slice and drops the redundant asset mention", async () => {

--- a/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
@@ -138,6 +138,14 @@ vitest.mock("~/database/db.server", () => {
       // INDIVIDUAL legacy path the booked total is implicitly 1, so the
       // default echoes one slice with `quantity: 1`. Qty-tracked tests
       // override per-describe `beforeEach` to model bigger slices.
+      // why: a kit-driven slice written before `sourceKitId` existed names its
+      // kit through this hop (`getKitIdsToAcquireBySlice`). These fixtures set
+      // `assetKitId` with no `sourceKitId`, so the lookup runs; no rows means
+      // the slice resolves to no kit, which is what the note assertions here
+      // expect — kit STATUS is covered in `service.server.test.ts`.
+      assetKit: {
+        findMany: vitest.fn().mockResolvedValue([]),
+      },
       bookingAsset: {
         findMany: vitest.fn().mockResolvedValue([{ quantity: 1 }]),
         // why: `computeBookingAssetSliceRemaining` reads a single slice's

--- a/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
@@ -1666,6 +1666,128 @@ describe("partialCheckoutBooking - quantity-tracked dispositions", () => {
       });
     });
 
+    /**
+     * A kit whose members are INDIVIDUAL assets, each booked as its own
+     * standalone slice — the shape `getKitIdsToAcquireBySlice` attributes
+     * through live membership rather than slice provenance.
+     */
+    const individualKitMembership = { id: "ak-ind", kitId: "kit-cases" };
+    const makeIndividualKitBooking = () => ({
+      id: "booking-1",
+      name: "Case run",
+      status: BookingStatus.ONGOING,
+      organizationId: "org-1",
+      custodianUserId: "user-1",
+      custodianTeamMemberId: null,
+      from: futureFrom,
+      to: futureTo,
+      _count: { bookingAssets: 2 },
+      bookingAssets: [
+        {
+          id: "ba-case-a",
+          quantity: 1,
+          assetKitId: null,
+          sourceKitId: null,
+          asset: {
+            id: "asset-case-a",
+            status: AssetStatus.AVAILABLE,
+            type: AssetType.INDIVIDUAL,
+            title: "Case A",
+            unitOfMeasure: null,
+            assetKits: [individualKitMembership],
+          },
+        },
+        {
+          id: "ba-case-b",
+          quantity: 1,
+          assetKitId: null,
+          sourceKitId: null,
+          asset: {
+            id: "asset-case-b",
+            status: AssetStatus.AVAILABLE,
+            type: AssetType.INDIVIDUAL,
+            title: "Case B",
+            unitOfMeasure: null,
+            assetKits: [individualKitMembership],
+          },
+        },
+      ],
+    });
+
+    /**
+     * Echo the requested slices back with their booked quantity, so the
+     * per-slice remaining reader sees real rows. `outSliceIds` are treated as
+     * already gone (remaining 0); everything else still owes its full quantity.
+     */
+    const mockSliceRows = (
+      booking: ReturnType<typeof makeIndividualKitBooking>
+    ) => {
+      (
+        db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+      ).mockImplementation((args?: { where?: { id?: { in?: string[] } } }) => {
+        const ids = args?.where?.id?.in;
+        if (!Array.isArray(ids)) return Promise.resolve([{ quantity: 1 }]);
+        return Promise.resolve(
+          booking.bookingAssets
+            .filter((ba) => ids.includes(ba.id))
+            .map((ba) => ({
+              id: ba.id,
+              assetId: ba.asset.id,
+              quantity: ba.quantity,
+              assetKitId: ba.assetKitId,
+              asset: { status: ba.asset.status },
+            }))
+        );
+      });
+    };
+
+    it("checks out a kit of INDIVIDUAL members once all of them are scanned", async () => {
+      expect.assertions(1);
+      // Regression: the kit decision must count INDIVIDUAL departures. Reading
+      // only the quantity-tracked disposition ledger leaves this kit unstamped
+      // forever, because that ledger never records an INDIVIDUAL claim.
+      const booking = makeIndividualKitBooking();
+      (
+        db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+      ).mockResolvedValue(booking);
+      mockSliceRows(booking);
+
+      await partialCheckoutBooking({
+        ...baseParams,
+        assetIds: ["asset-case-a", "asset-case-b"],
+      });
+
+      expect(db.kit.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: { in: ["kit-cases"] } }),
+          data: { status: KitStatus.CHECKED_OUT },
+        })
+      );
+    });
+
+    it("leaves a kit alone while one of its members is still unscanned", async () => {
+      expect.assertions(1);
+      // The other member's slice is absent from this batch. Its remaining must
+      // come from its own booked quantity, not from a missing map entry read as
+      // "owes nothing".
+      const booking = makeIndividualKitBooking();
+      (
+        db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+      ).mockResolvedValue(booking);
+      mockSliceRows(booking);
+
+      await partialCheckoutBooking({
+        ...baseParams,
+        assetIds: ["asset-case-a"],
+      });
+
+      expect(db.kit.updateMany).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { status: KitStatus.CHECKED_OUT },
+        })
+      );
+    });
+
     it("does not check out a kit when only the asset's free-pool slice left", async () => {
       expect.assertions(1);
       // Gloves holds two slices on this booking: 22 boxes standalone and 100

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -1833,8 +1833,13 @@ describe("getKitIdsToAcquire", () => {
     // why: overrides the module default, which derives a kitId from the input
     // (`kit-of-<id>`). A fixed row instead, so the assertion names the kit this
     // leg must resolve `ak-1` to rather than a value echoed back from the id.
+    // One-shot: `clearAllMocks` clears call history but NOT implementations, so
+    // a persistent override would answer for every later test in this file. The
+    // legacy hop issues exactly one read, so the queued value is consumed here.
     //@ts-expect-error missing vitest type
-    db.assetKit.findMany.mockResolvedValue([{ id: "ak-1", kitId: "kit-9" }]);
+    db.assetKit.findMany.mockResolvedValueOnce([
+      { id: "ak-1", kitId: "kit-9" },
+    ]);
 
     const result = await getKitIdsToAcquire({
       slices: [
@@ -1848,6 +1853,25 @@ describe("getKitIdsToAcquire", () => {
       where: { id: { in: ["ak-1"] }, organizationId: "org-1" },
       select: { id: true, kitId: true },
     });
+  });
+
+  it("stamps nothing for a standalone quantity-tracked slice on the release side too", async () => {
+    // Release has to be the exact inverse of acquire. A booking holding only
+    // free-pool units of a shared asset never stamped any kit, so it must not
+    // name one on the way out — otherwise cancelling it releases a kit that a
+    // different booking has out.
+    const result = await getKitIdsToAcquire({
+      slices: [
+        slice({
+          id: "ba-loose",
+          type: AssetType.QUANTITY_TRACKED,
+          memberships: ["kit-1", "kit-2"],
+        }),
+      ],
+      organizationId: "org-1",
+    });
+
+    expect(result).toEqual([]);
   });
 
   it("keeps a booking's kit slice and its free-pool slice apart", async () => {
@@ -13669,8 +13693,13 @@ describe("getKitIdsByBookingSlices", () => {
     // why: overrides the module default, which derives a kitId from the input
     // (`kit-of-<id>`). A fixed row instead, so the assertion names the kit this
     // leg must resolve `ak-1` to rather than a value echoed back from the id.
+    // One-shot: `clearAllMocks` clears call history but NOT implementations, so
+    // a persistent override would answer for every later test in this file. The
+    // legacy hop issues exactly one read, so the queued value is consumed here.
     //@ts-expect-error missing vitest type
-    db.assetKit.findMany.mockResolvedValue([{ id: "ak-1", kitId: "kit-9" }]);
+    db.assetKit.findMany.mockResolvedValueOnce([
+      { id: "ak-1", kitId: "kit-9" },
+    ]);
 
     const result = await getKitIdsByBookingSlices({
       slices: [{ assetId: "asset-1", assetKitId: "ak-1", sourceKitId: null }],
@@ -13697,8 +13726,10 @@ describe("getKitIdsByBookingSlices", () => {
   it("resolves nothing rather than throwing when a membership has vanished", async () => {
     // A concurrent detach legitimately removes the row between the two reads.
     // That means "no kit to release", never "reject the check-in".
+    // One-shot for the reason given above: an empty array left in place would
+    // answer the check-in suites that follow.
     //@ts-expect-error missing vitest type
-    db.assetKit.findMany.mockResolvedValue([]);
+    db.assetKit.findMany.mockResolvedValueOnce([]);
 
     const result = await getKitIdsByBookingSlices({
       slices: [

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -46,6 +46,7 @@ import {
   getPartiallyCheckedInAssetIds,
   getKitIdsByAssets,
   getKitIdsByBookingSlices,
+  getKitIdsToAcquire,
   updateBasicBooking,
   updateBookingAssets,
   buildKitSlicesForBooking,
@@ -1528,9 +1529,14 @@ describe("partialCheckinBooking", () => {
 
     // Verify kit status updated when all assets checked in
     expect(db.kit.updateMany).toHaveBeenCalledWith({
-      // why: partial check-in now scopes the kit status update by
-      // organizationId (cross-org IDOR hardening).
-      where: { id: { in: ["kit-1"] }, organizationId: "org-1" },
+      // why: the kit status update is scoped by organizationId (cross-org
+      // IDOR hardening) and by CHECKED_OUT, so a kit that shares a member
+      // with this booking but is held in custody is left alone.
+      where: {
+        id: { in: ["kit-1"] },
+        organizationId: "org-1",
+        status: KitStatus.CHECKED_OUT,
+      },
       data: { status: KitStatus.AVAILABLE },
     });
 
@@ -1685,8 +1691,8 @@ describe("getPartiallyCheckedInAssetIds", () => {
 });
 
 describe("getKitIdsByAssets", () => {
-  // An asset belongs to a kit when assetKits[0]?.kitId resolves to a kitId;
-  // an empty assetKits array represents "not in any kit".
+  // An asset belongs to a kit for every `AssetKit` row it carries; an empty
+  // assetKits array represents "not in any kit".
   it("should return unique kit IDs from assets", () => {
     const assets = [
       { id: "asset-1", assetKits: [{ kitId: "kit-1" }] },
@@ -1709,6 +1715,157 @@ describe("getKitIdsByAssets", () => {
     const result = getKitIdsByAssets(assets);
 
     expect(result).toEqual([]);
+  });
+
+  it("names every kit a quantity-tracked asset belongs to, not just the first", () => {
+    // A release leg: the kit reached through the second membership still owes
+    // this booking something, and a first-row read would strand it.
+    const assets = [
+      { id: "asset-1", assetKits: [{ kitId: "kit-1" }, { kitId: "kit-2" }] },
+    ];
+
+    expect(getKitIdsByAssets(assets).sort()).toEqual(["kit-1", "kit-2"]);
+  });
+});
+
+describe("getKitIdsToAcquire", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  /** One `BookingAsset` row, with the defaults most cases don't care about. */
+  function slice({
+    id,
+    assetKitId = null,
+    sourceKitId = null,
+    type = AssetType.QUANTITY_TRACKED,
+    memberships = [],
+  }: {
+    id: string;
+    assetKitId?: string | null;
+    sourceKitId?: string | null;
+    type?: AssetType;
+    memberships?: string[];
+  }) {
+    return {
+      id,
+      assetKitId,
+      sourceKitId,
+      asset: { type, assetKits: memberships.map((kitId) => ({ kitId })) },
+    };
+  }
+
+  it("stamps only the kit a slice was booked under", async () => {
+    // The asset sits in both kits; the booking took it from kit-1.
+    const result = await getKitIdsToAcquire({
+      slices: [
+        slice({
+          id: "ba-1",
+          sourceKitId: "kit-1",
+          memberships: ["kit-2", "kit-1"],
+        }),
+      ],
+      organizationId: "org-1",
+    });
+
+    expect(result).toEqual(["kit-1"]);
+  });
+
+  it("is unaffected by the order membership rows come back in", async () => {
+    const forwards = await getKitIdsToAcquire({
+      slices: [
+        slice({
+          id: "ba-1",
+          sourceKitId: "kit-1",
+          memberships: ["kit-1", "kit-2"],
+        }),
+      ],
+      organizationId: "org-1",
+    });
+    const backwards = await getKitIdsToAcquire({
+      slices: [
+        slice({
+          id: "ba-1",
+          sourceKitId: "kit-1",
+          memberships: ["kit-2", "kit-1"],
+        }),
+      ],
+      organizationId: "org-1",
+    });
+
+    expect(forwards).toEqual(backwards);
+  });
+
+  it("stamps no kit for a standalone quantity-tracked slice", async () => {
+    // Loose units come out of the free pool, which is a separate axis from the
+    // kit slices — every kit holding this asset stays intact.
+    const result = await getKitIdsToAcquire({
+      slices: [
+        slice({
+          id: "ba-1",
+          type: AssetType.QUANTITY_TRACKED,
+          memberships: ["kit-1", "kit-2"],
+        }),
+      ],
+      organizationId: "org-1",
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("stamps the kit for a standalone INDIVIDUAL slice", async () => {
+    // The one physical item leaves, so its kit is genuinely incomplete.
+    const result = await getKitIdsToAcquire({
+      slices: [
+        slice({
+          id: "ba-1",
+          type: AssetType.INDIVIDUAL,
+          memberships: ["kit-1"],
+        }),
+      ],
+      organizationId: "org-1",
+    });
+
+    expect(result).toEqual(["kit-1"]);
+  });
+
+  it("resolves a legacy kit-driven slice through the AssetKit hop", async () => {
+    // why: overrides the module default, which derives a kitId from the input
+    // (`kit-of-<id>`). A fixed row instead, so the assertion names the kit this
+    // leg must resolve `ak-1` to rather than a value echoed back from the id.
+    //@ts-expect-error missing vitest type
+    db.assetKit.findMany.mockResolvedValue([{ id: "ak-1", kitId: "kit-9" }]);
+
+    const result = await getKitIdsToAcquire({
+      slices: [
+        slice({ id: "ba-1", assetKitId: "ak-1", memberships: ["kit-3"] }),
+      ],
+      organizationId: "org-1",
+    });
+
+    expect(result).toEqual(["kit-9"]);
+    expect(db.assetKit.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ["ak-1"] }, organizationId: "org-1" },
+      select: { id: true, kitId: true },
+    });
+  });
+
+  it("keeps a booking's kit slice and its free-pool slice apart", async () => {
+    // Both slices are the same asset on the same booking: one booked under
+    // kit-1, one loose. Only the kit-driven one stamps.
+    const result = await getKitIdsToAcquire({
+      slices: [
+        slice({
+          id: "ba-kit",
+          sourceKitId: "kit-1",
+          memberships: ["kit-1", "kit-2"],
+        }),
+        slice({ id: "ba-loose", memberships: ["kit-1", "kit-2"] }),
+      ],
+      organizationId: "org-1",
+    });
+
+    expect(result).toEqual(["kit-1"]);
   });
 });
 
@@ -13627,7 +13784,11 @@ describe("checkinBooking - releases a kit detached mid-booking", () => {
     });
 
     expect(db.kit.updateMany).toHaveBeenCalledWith({
-      where: { id: { in: ["kit-1"] }, organizationId: "org-1" },
+      where: {
+        id: { in: ["kit-1"] },
+        organizationId: "org-1",
+        status: KitStatus.CHECKED_OUT,
+      },
       data: { status: KitStatus.AVAILABLE },
     });
   });

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -832,6 +832,33 @@ async function reconcileAssetStatusForBookingExit({
   }
 }
 
+/**
+ * Hands kits back to the shelf when a booking lets go of them.
+ *
+ * Only a kit this booking actually took out is released: the kit-id sets that
+ * reach here are deliberately over-inclusive (see {@link getKitIdsByAssets}),
+ * and a kit that shares a `QUANTITY_TRACKED` member with the booking can be
+ * sitting in a custodian's hands for reasons this booking knows nothing about.
+ * `status: CHECKED_OUT` makes the surplus a no-op instead of stranding such a
+ * kit as AVAILABLE with its `KitCustody` row still attached.
+ *
+ * @param client Pass the active `tx` when called inside a transaction.
+ */
+async function releaseCheckedOutKits(
+  client: Pick<ExtendedPrismaClient, "kit">,
+  { kitIds, organizationId }: { kitIds: string[]; organizationId: string }
+) {
+  if (kitIds.length === 0) return;
+  return client.kit.updateMany({
+    where: {
+      id: { in: kitIds },
+      organizationId,
+      status: KitStatus.CHECKED_OUT,
+    },
+    data: { status: KitStatus.AVAILABLE },
+  });
+}
+
 async function updateBookingKitStates({
   kitIds,
   status,
@@ -843,6 +870,10 @@ async function updateBookingKitStates({
   organizationId: string;
 }) {
   try {
+    if (status === KitStatus.AVAILABLE) {
+      return await releaseCheckedOutKits(db, { kitIds, organizationId });
+    }
+
     return await db.kit.updateMany({
       where: { id: { in: kitIds }, organizationId },
       data: { status },
@@ -3055,11 +3086,14 @@ export async function checkoutBooking({
     };
 
     /**
-     * Get the kitIds because we need them to update their status later on
+     * The kits this check-out takes off the shelf, so their status can be
+     * stamped below. Resolved per slice: a kit is out only when the booking
+     * holds its own units. See {@link getKitIdsToAcquire}.
      */
-    const kitIds = getKitIdsByAssets(
-      bookingFound.bookingAssets.map((ba) => ba.asset)
-    );
+    const kitIds = await getKitIdsToAcquire({
+      slices: bookingFound.bookingAssets,
+      organizationId,
+    });
     const hasKits = kitIds.length > 0;
 
     const isEarlyCheckout = isBookingEarlyCheckout(bookingFound.from!);
@@ -3441,9 +3475,10 @@ export async function fulfilModelRequestsAndCheckout({
      * kits on the booking so kit status reflects reality after commit
      * (matches `checkoutBooking`'s behaviour).
      */
-    const preExistingKitIds = getKitIdsByAssets(
-      bookingFound.bookingAssets.map((ba) => ba.asset)
-    );
+    const preExistingKitIds = await getKitIdsToAcquire({
+      slices: bookingFound.bookingAssets,
+      organizationId,
+    });
 
     /**
      * Single atomic transaction:
@@ -4899,10 +4934,16 @@ export async function checkinBooking({
           // Same union as the resolution above. Filtering on membership alone
           // yields [] for a kit reached only through provenance, and `.every()`
           // on [] is vacuously true — which would release it unconditionally.
+          //
+          // Membership is matched across EVERY `AssetKit` row: a
+          // `QUANTITY_TRACKED` asset can belong to several kits, and the rows
+          // come back unordered, so a first-row read tests an arbitrary one.
           const kitAssetsInBooking = bookingFoundAssets.filter(
             (asset) =>
               sliceKitAssetIds.get(kitId)?.has(asset.id) ||
-              asset.assetKits?.[0]?.kitId === kitId
+              (asset.assetKits ?? []).some(
+                (membership) => membership?.kitId === kitId
+              )
           );
           return kitAssetsInBooking.every(
             (asset) =>
@@ -5314,12 +5355,10 @@ export async function checkinBooking({
         }
         /* If there are any kits associated with the booking, then update their status */
         if (hasKits) {
-          if (kitsToCheckin.length > 0) {
-            await tx.kit.updateMany({
-              where: { id: { in: kitsToCheckin }, organizationId },
-              data: { status: KitStatus.AVAILABLE },
-            });
-          }
+          await releaseCheckedOutKits(tx, {
+            kitIds: kitsToCheckin,
+            organizationId,
+          });
         }
 
         // Activity events — one BOOKING_CHECKED_IN per BookingAsset ROW that
@@ -7063,12 +7102,10 @@ export async function partialCheckinBooking({
         (kitId) => !kitIdsStillOut.has(kitId)
       );
 
-      if (completeKitIds.length > 0) {
-        await tx.kit.updateMany({
-          where: { id: { in: completeKitIds }, organizationId },
-          data: { status: KitStatus.AVAILABLE },
-        });
-      }
+      await releaseCheckedOutKits(tx, {
+        kitIds: completeKitIds,
+        organizationId,
+      });
 
       // Activity events — one BOOKING_PARTIAL_CHECKIN per asset that had
       // activity in this session (qty disposition or individual flip).
@@ -7595,10 +7632,14 @@ export async function partialCheckoutBooking({
             select: {
               id: true,
               quantity: true,
-              // Slice discriminator (Layer 2/3): `null` = standalone (free
-              // pool), non-null = kit-driven slice (FK → `AssetKit.id`). Drives
-              // the per-slice checkout note label ("standalone" vs "in kit X").
+              // Slice discriminator: `null` = standalone (free pool), non-null
+              // = kit-driven slice (FK → `AssetKit.id`). Drives the per-slice
+              // checkout note label ("standalone" vs "in kit X").
               assetKitId: true,
+              // Kit provenance, paired with `assetKitId` so the slice can name
+              // the kit it was booked under even after a detach. Both are
+              // required by `getKitIdsToAcquireBySlice`.
+              sourceKitId: true,
               asset: {
                 select: {
                   id: true,
@@ -8019,29 +8060,41 @@ export async function partialCheckoutBooking({
       });
     }
 
-    // For kits: only update kit status if ALL assets of a kit are being checked out.
-    // Post-pivot, kit membership lives on `Asset.assetKits[]`; collapse to the
-    // first kitId per asset (kits-as-bag-of-assets is still a 1:1 relation in
-    // the customer-facing semantics of this flow).
-    const assetsBeingCheckedOut = bookingAssetsDeduped.filter((a) =>
-      assetIdsToCheckOut.includes(a.id)
-    );
-    const kitIdsBeingCheckedOut = getKitIdsByAssets(assetsBeingCheckedOut);
+    /**
+     * A kit goes CHECKED_OUT only once every asset it contributed to this
+     * booking is leaving in this batch.
+     *
+     * Kit attribution is resolved per SLICE: a booking holds a kit through the
+     * rows it booked under that kit, not through its members' other kit
+     * memberships. See {@link getKitIdsToAcquireBySlice}.
+     *
+     * The comparison itself stays at asset grain because progressive checkout
+     * addresses assets by id — `assetIdsToCheckOut` cannot distinguish two
+     * slices of the same asset.
+     */
+    const assetIdsToCheckOutSet = new Set(assetIdsToCheckOut);
+    const acquireKitIdsBySliceId = await getKitIdsToAcquireBySlice({
+      slices: bookingFound.bookingAssets,
+      organizationId,
+    });
 
-    // Only process kits where ALL their assets in this booking are being checked out
-    const completeKitIds: string[] = [];
-    for (const kitId of kitIdsBeingCheckedOut) {
-      const kitAssetsInBooking = bookingAssetsDeduped.filter(
-        (a) => a.assetKits?.[0]?.kitId === kitId
-      );
-      const kitAssetsBeingCheckedOut = assetsBeingCheckedOut.filter(
-        (a) => a.assetKits?.[0]?.kitId === kitId
-      );
-
-      if (kitAssetsInBooking.length === kitAssetsBeingCheckedOut.length) {
-        completeKitIds.push(kitId);
+    /** Kit id → asset ids that kit contributed to this booking. */
+    const assetIdsByKitId = new Map<string, Set<string>>();
+    for (const ba of bookingFound.bookingAssets) {
+      for (const kitId of acquireKitIdsBySliceId.get(ba.id) ?? []) {
+        const bucket = assetIdsByKitId.get(kitId) ?? new Set<string>();
+        bucket.add(ba.asset.id);
+        assetIdsByKitId.set(kitId, bucket);
       }
     }
+
+    // Every kit in the map contributed at least one asset, so a kit with none
+    // of them in this batch fails the equality and is left CHECKED_OUT.
+    const completeKitIds = [...assetIdsByKitId]
+      .filter(([, assetIds]) =>
+        [...assetIds].every((assetId) => assetIdsToCheckOutSet.has(assetId))
+      )
+      .map(([kitId]) => kitId);
 
     /**
      * Per-asset qty-checkout summary populated INSIDE the tx and consumed by the
@@ -10222,10 +10275,7 @@ export async function cancelBooking({
 
         /** If there are any kits, then update their status as well */
         if (hasKits) {
-          await tx.kit.updateMany({
-            where: { id: { in: kitIds }, organizationId },
-            data: { status: KitStatus.AVAILABLE },
-          });
+          await releaseCheckedOutKits(tx, { kitIds, organizationId });
         }
       }
 
@@ -11839,14 +11889,7 @@ export async function removeAssets({
       b.status === BookingStatus.ONGOING ||
       b.status === BookingStatus.OVERDUE
     ) {
-      if (kitIds.length > 0) {
-        // Kit status keeps the blanket flip — kit status is a coarser
-        // indicator and out of scope for the per-asset #99 fix.
-        await db.kit.updateMany({
-          where: { id: { in: kitIds }, organizationId },
-          data: { status: KitStatus.AVAILABLE },
-        });
-      }
+      await releaseCheckedOutKits(db, { kitIds, organizationId });
     }
 
     const userForNotes = { firstName, lastName, displayName, id: userId };
@@ -12197,10 +12240,8 @@ export async function deleteBooking(
       });
     }
 
-    // Kit blanket flip — out of the tx on purpose. Kit status is a coarser
-    // indicator than asset status; the singular cancel path treats it the
-    // same way and the bug #99 atomicity fix is intentionally scoped to
-    // assets.
+    // Outside the tx on purpose: kit status is a coarser indicator than asset
+    // status, and the singular cancel path releases kits the same way.
     if (activeBooking && hasKits) {
       await updateBookingKitStates({
         kitIds: [...uniqueKitIds],
@@ -12740,11 +12781,28 @@ type AssetWithKitId = Pick<Asset, "id"> & {
   assetKits: { kitId: string }[];
 };
 
+/**
+ * Every kit these assets are LIVE members of.
+ *
+ * A release-path leg only. It answers "which kits might this booking owe
+ * something to", so it is deliberately over-inclusive: a redundant release is a
+ * no-op write, while a kit missed stays stuck with no way out of the UI. The
+ * release writes are scoped to `status: CHECKED_OUT` so the surplus cannot
+ * disturb a kit held in custody.
+ *
+ * Never use it to ACQUIRE. Membership cannot say which kit a booking took an
+ * asset from, and a `QUANTITY_TRACKED` asset may belong to several kits at
+ * once — reach for {@link getKitIdsToAcquire} instead.
+ *
+ * EVERY membership counts, not just the first: `AssetKit` rows come back
+ * unordered, so a first-row read names an arbitrary kit and drops the rest.
+ */
 export function getKitIdsByAssets(assets: AssetWithKitId[]) {
   // Defensive `?.` on `assetKits` tolerates fixtures / payloads where the
   // pivot relation isn't projected (older mocks, narrower selects).
   const allKitIds = assets
-    .map((a) => a.assetKits?.[0]?.kitId)
+    .flatMap((a) => a.assetKits ?? [])
+    .map((membership) => membership?.kitId)
     .filter((id): id is string => Boolean(id));
 
   const uniqueKitIds = new Set(allKitIds);
@@ -12801,6 +12859,118 @@ async function resolveKitIdByAssetKitId({
     select: { id: true, kitId: true },
   });
   return new Map(rows.map((r) => [r.id, r.kitId]));
+}
+
+/**
+ * One `BookingAsset` row, with everything needed to decide which kits it takes
+ * off the shelf.
+ *
+ * `asset.type` is required because the answer differs by type for a slice that
+ * carries no provenance — see {@link getKitIdsToAcquire}.
+ */
+type AcquireSliceKitAttribution = {
+  /** `BookingAsset.id` — the grain {@link getKitIdsToAcquireBySlice} answers at. */
+  id: string;
+  assetKitId: string | null;
+  sourceKitId: string | null;
+  asset: {
+    type: AssetType;
+    assetKits: { kitId: string }[];
+  };
+};
+
+/**
+ * The kits a check-out takes off the shelf, resolved per SLICE.
+ *
+ * `Kit.status` answers "is this kit out", so only a booking that actually took
+ * the kit's own units may stamp it. Three cases, and the middle one is the
+ * reason this cannot be answered from the asset alone:
+ *
+ * | Slice                                   | Kits it stamps                    |
+ * | --------------------------------------- | --------------------------------- |
+ * | kit-driven (`sourceKitId`/`assetKitId`) | exactly the kit it was booked under |
+ * | standalone, `INDIVIDUAL`                | the asset's live kits             |
+ * | standalone, `QUANTITY_TRACKED`          | none                              |
+ *
+ * A kit-driven slice belongs to the kit it names, never to its asset's other
+ * kits: a `QUANTITY_TRACKED` asset may sit in several kits at distinct slices,
+ * so reading membership instead would stamp an arbitrary one of them — and
+ * `AssetKit` rows come back unordered, so "arbitrary" can differ between the
+ * check-out and the check-in that has to undo it.
+ *
+ * A standalone slice draws on the free pool, which is a separate axis from the
+ * kit slices (`enforce_asset_kit_sum_within_total` bounds the kit axis alone).
+ * Booking loose units of a `QUANTITY_TRACKED` kit member therefore leaves every
+ * kit holding that asset fully intact, and stamps nothing. An `INDIVIDUAL`
+ * asset has no pool to draw on — the one physical item leaves, so its kit is
+ * genuinely incomplete and does get stamped.
+ *
+ * Slice-grained, because a `QUANTITY_TRACKED` asset can hold a standalone slice
+ * and one slice per kit it belongs to on the SAME booking (the two partial
+ * uniques on `BookingAsset`). Collapsed to an asset id, the standalone slice's
+ * answer and the kit slice's answer are indistinguishable.
+ *
+ * @param args.slices The booking's `BookingAsset` rows.
+ * @param args.client Pass the active `tx` when called inside a transaction.
+ * @returns `BookingAsset.id` to the kit ids that slice takes off the shelf. A
+ *   slice that stamps no kit is absent from the map.
+ */
+export async function getKitIdsToAcquireBySlice({
+  slices,
+  organizationId,
+  client = db,
+}: {
+  slices: AcquireSliceKitAttribution[];
+  organizationId: Organization["id"];
+  client?: Pick<ExtendedPrismaClient, "assetKit">;
+}): Promise<Map<string, Set<string>>> {
+  const kitIdByAssetKitId = await resolveKitIdByAssetKitId({
+    slices,
+    organizationId,
+    client,
+  });
+
+  const kitIdsBySliceId = new Map<string, Set<string>>();
+  for (const slice of slices) {
+    const kitIds = new Set<string>();
+
+    if (slice.sourceKitId || slice.assetKitId) {
+      const kitId =
+        slice.sourceKitId ??
+        (slice.assetKitId
+          ? kitIdByAssetKitId.get(slice.assetKitId)
+          : undefined);
+      if (kitId) kitIds.add(kitId);
+    } else if (slice.asset?.type === AssetType.INDIVIDUAL) {
+      for (const membership of slice.asset.assetKits ?? []) {
+        if (membership?.kitId) kitIds.add(membership.kitId);
+      }
+    }
+
+    if (kitIds.size > 0) kitIdsBySliceId.set(slice.id, kitIds);
+  }
+
+  return kitIdsBySliceId;
+}
+
+/**
+ * Flattened {@link getKitIdsToAcquireBySlice}, for the callers that only need
+ * "which kits does this check-out stamp".
+ *
+ * @param args.client Pass the active `tx` when called inside a transaction.
+ * @returns Unique kit ids to stamp, in first-seen order.
+ */
+export async function getKitIdsToAcquire(args: {
+  slices: AcquireSliceKitAttribution[];
+  organizationId: Organization["id"];
+  client?: Pick<ExtendedPrismaClient, "assetKit">;
+}): Promise<string[]> {
+  const kitIdsBySliceId = await getKitIdsToAcquireBySlice(args);
+  const kitIds = new Set<string>();
+  for (const sliceKitIds of kitIdsBySliceId.values()) {
+    for (const kitId of sliceKitIds) kitIds.add(kitId);
+  }
+  return [...kitIds];
 }
 
 /**
@@ -13222,9 +13392,9 @@ export async function bulkDeleteBookings({
           organizationId,
         });
 
-        await tx.kit.updateMany({
-          where: { id: { in: [...uniqueKitIds] }, organizationId },
-          data: { status: KitStatus.AVAILABLE },
+        await releaseCheckedOutKits(tx, {
+          kitIds: [...uniqueKitIds],
+          organizationId,
         });
       }
 
@@ -13647,9 +13817,9 @@ export async function bulkCancelBookings({
         });
 
         /** Making kits available */
-        await tx.kit.updateMany({
-          where: { id: { in: [...uniqueKitIds] }, organizationId },
-          data: { status: KitStatus.AVAILABLE },
+        await releaseCheckedOutKits(tx, {
+          kitIds: [...uniqueKitIds],
+          organizationId,
         });
       }
 

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -835,23 +835,82 @@ async function reconcileAssetStatusForBookingExit({
 /**
  * Hands kits back to the shelf when a booking lets go of them.
  *
- * Only a kit this booking actually took out is released: the kit-id sets that
- * reach here are deliberately over-inclusive (see {@link getKitIdsByAssets}),
- * and a kit that shares a `QUANTITY_TRACKED` member with the booking can be
- * sitting in a custodian's hands for reasons this booking knows nothing about.
- * `status: CHECKED_OUT` makes the surplus a no-op instead of stranding such a
- * kit as AVAILABLE with its `KitCustody` row still attached.
+ * Two things stand between the caller's kit ids and the write, because
+ * `Kit.status` is workspace-wide state that one booking's exit must not
+ * overwrite on another's behalf:
+ *
+ *  - `status: CHECKED_OUT` leaves a kit held in a custodian's hands alone, so
+ *    it cannot be stranded AVAILABLE with its `KitCustody` row still attached;
+ *  - a kit any OTHER live booking still has out is dropped outright. That one
+ *    the status filter cannot catch, because such a kit is legitimately
+ *    CHECKED_OUT — and releasing it would let it be booked again while it is
+ *    physically away (`assertKitsAddableToActiveBooking` gates on this column).
  *
  * @param client Pass the active `tx` when called inside a transaction.
+ * @param args.excludeBookingIds The exiting bookings, so their own slices
+ *   cannot pin the kit, or each other.
  */
 async function releaseCheckedOutKits(
-  client: Pick<ExtendedPrismaClient, "kit">,
-  { kitIds, organizationId }: { kitIds: string[]; organizationId: string }
+  client: Pick<ExtendedPrismaClient, "kit" | "assetKit" | "bookingAsset">,
+  {
+    kitIds,
+    organizationId,
+    excludeBookingIds,
+  }: {
+    kitIds: string[];
+    organizationId: string;
+    excludeBookingIds: string[];
+  }
 ) {
   if (kitIds.length === 0) return;
+
+  // `sourceKitId` names the kit directly; the `assetKitId` leg needs the pivot
+  // ids to compare against, for slices written before that column existed.
+  const membershipRows = await client.assetKit.findMany({
+    where: { kitId: { in: kitIds }, organizationId },
+    select: { id: true, kitId: true },
+  });
+  const kitIdByAssetKitId = new Map(
+    membershipRows.map((row) => [row.id, row.kitId])
+  );
+
+  const slicesStillOut = await client.bookingAsset.findMany({
+    where: {
+      bookingId: { notIn: excludeBookingIds },
+      booking: {
+        status: { in: [BookingStatus.ONGOING, BookingStatus.OVERDUE] },
+        organizationId,
+      },
+      // A live booking is not by itself evidence that it holds the kit — only
+      // the slice's own markers say that. A partially returned
+      // QUANTITY_TRACKED slice keeps a null `checkedInAt` and still counts,
+      // which is correct: some of its units are still out.
+      checkedOutAt: { not: null },
+      checkedInAt: null,
+      OR: [
+        { sourceKitId: { in: kitIds } },
+        { assetKitId: { in: [...kitIdByAssetKitId.keys()] } },
+      ],
+    },
+    select: { assetKitId: true, sourceKitId: true },
+  });
+
+  const heldByAnotherBooking = new Set<string>();
+  for (const slice of slicesStillOut) {
+    const kitId =
+      slice.sourceKitId ??
+      (slice.assetKitId ? kitIdByAssetKitId.get(slice.assetKitId) : undefined);
+    if (kitId) heldByAnotherBooking.add(kitId);
+  }
+
+  const releasableKitIds = kitIds.filter(
+    (kitId) => !heldByAnotherBooking.has(kitId)
+  );
+  if (releasableKitIds.length === 0) return;
+
   return client.kit.updateMany({
     where: {
-      id: { in: kitIds },
+      id: { in: releasableKitIds },
       organizationId,
       status: KitStatus.CHECKED_OUT,
     },
@@ -863,15 +922,22 @@ async function updateBookingKitStates({
   kitIds,
   status,
   organizationId,
+  excludeBookingIds,
 }: {
   kitIds: string[];
   status: KitStatus;
   /** Org that owns the booking — scopes the update so we never touch another org's kits */
   organizationId: string;
+  /** The exiting bookings, for the release path's held-elsewhere check. */
+  excludeBookingIds: string[];
 }) {
   try {
     if (status === KitStatus.AVAILABLE) {
-      return await releaseCheckedOutKits(db, { kitIds, organizationId });
+      return await releaseCheckedOutKits(db, {
+        kitIds,
+        organizationId,
+        excludeBookingIds,
+      });
     }
 
     return await db.kit.updateMany({
@@ -4805,12 +4871,18 @@ export async function checkinBooking({
       slices: bookingFound.bookingAssets,
       organizationId,
     });
-    const kitIds = [
-      ...new Set([
-        ...getKitIdsByAssets(bookingFoundAssets),
-        ...sliceKitAssetIds.keys(),
-      ]),
-    ];
+    /**
+     * Kits this booking took out, resolved exactly as the check-out that
+     * stamped them did — release has to be the inverse of acquire, or it
+     * either strands a kit or hands back one it never held. In particular a
+     * standalone `QUANTITY_TRACKED` slice stamps no kit, so it releases none:
+     * its units come out of the free pool, and every kit holding that asset
+     * kept its own slice throughout.
+     */
+    const kitIds = await getKitIdsToAcquire({
+      slices: bookingFound.bookingAssets,
+      organizationId,
+    });
     const hasKits = kitIds.length > 0;
 
     const isEarlyCheckin = isBookingEarlyCheckin(bookingFound.to!);
@@ -5358,6 +5430,7 @@ export async function checkinBooking({
           await releaseCheckedOutKits(tx, {
             kitIds: kitsToCheckin,
             organizationId,
+            excludeBookingIds: [id],
           });
         }
 
@@ -6474,6 +6547,7 @@ export async function partialCheckinBooking({
         assetKitId: ba.assetKitId ?? null,
         sourceKitId: ba.sourceKitId ?? null,
         assetKits: ba.asset?.assetKits ?? [],
+        assetType: ba.asset.type,
       })),
       organizationId,
     });
@@ -7075,7 +7149,14 @@ export async function partialCheckinBooking({
             id: true,
             assetKitId: true,
             sourceKitId: true,
-            asset: { select: { assetKits: { select: { kitId: true } } } },
+            asset: {
+              select: {
+                // `type` decides whether a slice with no provenance answers
+                // from live membership — see `getKitIdsBySlice`.
+                type: true,
+                assetKits: { select: { kitId: true } },
+              },
+            },
           },
         });
         const unseenSlices = stillOutNow.filter(
@@ -7088,6 +7169,7 @@ export async function partialCheckinBooking({
               assetKitId: slice.assetKitId,
               sourceKitId: slice.sourceKitId,
               assetKits: slice.asset?.assetKits ?? [],
+              assetType: slice.asset.type,
             })),
             organizationId,
             client: tx,
@@ -7105,6 +7187,7 @@ export async function partialCheckinBooking({
       await releaseCheckedOutKits(tx, {
         kitIds: completeKitIds,
         organizationId,
+        excludeBookingIds: [id],
       });
 
       // Activity events — one BOOKING_PARTIAL_CHECKIN per asset that had
@@ -8061,40 +8144,30 @@ export async function partialCheckoutBooking({
     }
 
     /**
-     * A kit goes CHECKED_OUT only once every asset it contributed to this
-     * booking is leaving in this batch.
+     * The slices each kit contributed to this booking.
      *
-     * Kit attribution is resolved per SLICE: a booking holds a kit through the
-     * rows it booked under that kit, not through its members' other kit
-     * memberships. See {@link getKitIdsToAcquireBySlice}.
-     *
-     * The comparison itself stays at asset grain because progressive checkout
-     * addresses assets by id — `assetIdsToCheckOut` cannot distinguish two
-     * slices of the same asset.
+     * Kept at SLICE grain all the way to the decision. An asset id cannot
+     * carry the answer: a `QUANTITY_TRACKED` asset can hold a standalone slice
+     * AND a kit-driven slice on one booking, so "this asset is going out" is
+     * true when only the free-pool half leaves and the kit's units have not
+     * moved. Which kits a slice belongs to is
+     * {@link getKitIdsToAcquireBySlice}'s answer; whether those slices have
+     * actually left is decided inside the transaction, once the markers and
+     * per-slice quantities this batch writes are visible.
      */
-    const assetIdsToCheckOutSet = new Set(assetIdsToCheckOut);
     const acquireKitIdsBySliceId = await getKitIdsToAcquireBySlice({
       slices: bookingFound.bookingAssets,
       organizationId,
     });
 
-    /** Kit id → asset ids that kit contributed to this booking. */
-    const assetIdsByKitId = new Map<string, Set<string>>();
+    const sliceIdsByKitId = new Map<string, Set<string>>();
     for (const ba of bookingFound.bookingAssets) {
       for (const kitId of acquireKitIdsBySliceId.get(ba.id) ?? []) {
-        const bucket = assetIdsByKitId.get(kitId) ?? new Set<string>();
-        bucket.add(ba.asset.id);
-        assetIdsByKitId.set(kitId, bucket);
+        const bucket = sliceIdsByKitId.get(kitId) ?? new Set<string>();
+        bucket.add(ba.id);
+        sliceIdsByKitId.set(kitId, bucket);
       }
     }
-
-    // Every kit in the map contributed at least one asset, so a kit with none
-    // of them in this batch fails the equality and is left CHECKED_OUT.
-    const completeKitIds = [...assetIdsByKitId]
-      .filter(([, assetIds]) =>
-        [...assetIds].every((assetId) => assetIdsToCheckOutSet.has(assetId))
-      )
-      .map(([kitId]) => kitId);
 
     /**
      * Per-asset qty-checkout summary populated INSIDE the tx and consumed by the
@@ -8570,14 +8643,6 @@ export async function partialCheckoutBooking({
           });
         }
 
-        // Only update kit status for kits that are completely checked out
-        if (completeKitIds.length > 0) {
-          await tx.kit.updateMany({
-            where: { id: { in: completeKitIds }, organizationId },
-            data: { status: KitStatus.CHECKED_OUT },
-          });
-        }
-
         /**
          * `PartialBookingCheckout` session row. `assetIds[i]` and `quantities[i]`
          * are positionally aligned: every entry corresponds to one disposition
@@ -8783,6 +8848,44 @@ export async function partialCheckoutBooking({
             // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: slice ids come from this booking's own rows, loaded org-scoped by this action's booking lookup
             where: { id: sliceId, bookingId: id },
             data: { checkedOutQuantity: { increment: units } },
+          });
+        }
+
+        /**
+         * A kit is CHECKED_OUT once every slice it contributed to this booking
+         * has nothing left to send out, and only when this batch is what moved
+         * one of them.
+         *
+         * Decided per SLICE, never per asset: a `QUANTITY_TRACKED` asset can
+         * hold a standalone slice and a kit-driven slice on one booking, so its
+         * id appears on both sides and says nothing about which units left.
+         * Sending the free-pool half out must leave the kit alone.
+         *
+         * `sliceCommittedRemainingBySlice` is what each slice still owed before
+         * this batch, so a slice already fully out enters at 0 and a slice this
+         * batch finishes lands there — no re-read needed, and the arithmetic is
+         * the same one the per-slice caps were enforced with.
+         */
+        const claimedThisBatch = (sliceId: string) =>
+          claimedBySliceThisBatch.get(sliceId) ?? 0;
+        const remainingAfterBatch = (sliceId: string) =>
+          (sliceCommittedRemainingBySlice.get(sliceId) ?? 0) -
+          claimedThisBatch(sliceId);
+
+        const completeKitIds: string[] = [];
+        for (const [kitId, sliceIds] of sliceIdsByKitId) {
+          const ids = [...sliceIds];
+          // A kit none of whose slices moved keeps the status it had.
+          if (!ids.some((sliceId) => claimedThisBatch(sliceId) > 0)) continue;
+          if (ids.every((sliceId) => remainingAfterBatch(sliceId) <= 0)) {
+            completeKitIds.push(kitId);
+          }
+        }
+
+        if (completeKitIds.length > 0) {
+          await tx.kit.updateMany({
+            where: { id: { in: completeKitIds }, organizationId },
+            data: { status: KitStatus.CHECKED_OUT },
           });
         }
 
@@ -10186,6 +10289,9 @@ export async function cancelBooking({
               asset: {
                 select: {
                   id: true,
+                  // `type` decides whether a standalone slice releases this
+                  // asset's kits — see `getKitIdsToAcquire`.
+                  type: true,
                   assetKits: { select: { kitId: true } },
                 },
               },
@@ -10229,19 +10335,17 @@ export async function cancelBooking({
     }
 
     /**
-     * Kits to release, from live membership AND the booking's own slices.
-     * A kit released redundantly is a no-op write; a kit missed stays stuck.
+     * Kits this booking took out, resolved exactly as the check-out that
+     * stamped them did — release has to be the inverse of acquire, or it
+     * either strands a kit or hands back one it never held. In particular a
+     * standalone `QUANTITY_TRACKED` slice stamps no kit, so it releases none:
+     * its units come out of the free pool, and every kit holding that asset
+     * kept its own slice throughout.
      */
-    const cancelSliceKitIds = await getKitIdsByBookingSlices({
+    const kitIds = await getKitIdsToAcquire({
       slices: bookingFound.bookingAssets,
       organizationId,
     });
-    const kitIds = [
-      ...new Set([
-        ...getKitIdsByAssets(cancelAssets),
-        ...cancelSliceKitIds.keys(),
-      ]),
-    ];
     const hasKits = kitIds.length > 0;
 
     const booking = await db.$transaction(async (tx) => {
@@ -10275,7 +10379,11 @@ export async function cancelBooking({
 
         /** If there are any kits, then update their status as well */
         if (hasKits) {
-          await releaseCheckedOutKits(tx, { kitIds, organizationId });
+          await releaseCheckedOutKits(tx, {
+            kitIds,
+            organizationId,
+            excludeBookingIds: [bookingFound.id],
+          });
         }
       }
 
@@ -11889,7 +11997,11 @@ export async function removeAssets({
       b.status === BookingStatus.ONGOING ||
       b.status === BookingStatus.OVERDUE
     ) {
-      await releaseCheckedOutKits(db, { kitIds, organizationId });
+      await releaseCheckedOutKits(db, {
+        kitIds,
+        organizationId,
+        excludeBookingIds: [id],
+      });
     }
 
     const userForNotes = { firstName, lastName, displayName, id: userId };
@@ -12113,6 +12225,9 @@ export async function deleteBooking(
           asset: {
             select: {
               id: true,
+              // `type` decides whether a standalone slice releases this
+              // asset's kits — see `getKitIdsToAcquire`.
+              type: true,
               assetKits: { select: { kitId: true } },
             },
           },
@@ -12140,22 +12255,15 @@ export async function deleteBooking(
         ? currentBooking
         : null;
 
-    const activeBookingAssets =
-      activeBooking?.bookingAssets.map((ba) => ba.asset) ?? [];
-    /**
-     * Kits to release, from live membership AND the booking's own slices.
-     * A kit released redundantly is a no-op write; a kit missed stays stuck.
-     */
-    const deleteSliceKitIds = activeBooking
-      ? await getKitIdsByBookingSlices({
-          slices: activeBooking.bookingAssets,
-          organizationId,
-        })
-      : new Map<string, Set<string>>();
-    const uniqueKitIds = new Set([
-      ...getKitIdsByAssets(activeBookingAssets),
-      ...deleteSliceKitIds.keys(),
-    ]);
+    // Release mirrors acquire — see the twin in `checkinBooking`.
+    const uniqueKitIds = new Set(
+      activeBooking
+        ? await getKitIdsToAcquire({
+            slices: activeBooking.bookingAssets,
+            organizationId,
+          })
+        : []
+    );
     const hasKits = uniqueKitIds.size > 0;
 
     // Capture the active asset IDs BEFORE entering the tx: `Booking.delete`
@@ -12247,6 +12355,7 @@ export async function deleteBooking(
         kitIds: [...uniqueKitIds],
         status: KitStatus.AVAILABLE,
         organizationId,
+        excludeBookingIds: [b.id],
       });
     }
 
@@ -12784,15 +12893,11 @@ type AssetWithKitId = Pick<Asset, "id"> & {
 /**
  * Every kit these assets are LIVE members of.
  *
- * A release-path leg only. It answers "which kits might this booking owe
- * something to", so it is deliberately over-inclusive: a redundant release is a
- * no-op write, while a kit missed stays stuck with no way out of the UI. The
- * release writes are scoped to `status: CHECKED_OUT` so the surplus cannot
- * disturb a kit held in custody.
- *
- * Never use it to ACQUIRE. Membership cannot say which kit a booking took an
- * asset from, and a `QUANTITY_TRACKED` asset may belong to several kits at
- * once — reach for {@link getKitIdsToAcquire} instead.
+ * Naming only, for note and summary text that groups an operation's assets
+ * under a kit heading. It cannot decide `Kit.status` in either direction:
+ * membership does not say which kit a booking took an asset from, and a
+ * `QUANTITY_TRACKED` asset may belong to several kits at once. Acquire and
+ * release both go through {@link getKitIdsToAcquire}, which reads the slice.
  *
  * EVERY membership counts, not just the first: `AssetKit` rows come back
  * unordered, so a first-row read names an arbitrary kit and drops the rest.
@@ -12974,8 +13079,8 @@ export async function getKitIdsToAcquire(args: {
 }
 
 /**
- * Release-path sibling of {@link getKitIdsByAssets}: resolves kits from the
- * BOOKING's own rows rather than from the assets' current membership.
+ * The kits a booking holds, resolved from the BOOKING's own rows rather than
+ * from the assets' current membership.
  *
  * A kit whose member was detached while the booking was live is invisible to
  * membership-based resolution, so nothing releases it and `Kit.status` stays
@@ -12998,11 +13103,10 @@ export async function getKitIdsToAcquire(args: {
  *
  * @param client Pass the active `tx` when called inside a transaction.
  *
- * ALWAYS UNION the result with {@link getKitIdsByAssets}, never substitute it.
- * A standalone slice carries no provenance by design even when its asset is a
- * live kit member, and the acquire paths stamp that kit CHECKED_OUT from
- * membership — so provenance alone would leave exactly those kits stuck.
- * Never use on an acquire path: it names kits the asset has already left.
+ * Provenance ALONE cannot answer "which kits did this booking take out": a
+ * standalone slice carries none by design, and one belonging to an INDIVIDUAL
+ * kit member does empty its kit. {@link getKitIdsToAcquire} joins the two legs
+ * and is what both the acquire and the release writes read.
  */
 export async function getKitIdsByBookingSlices({
   slices,
@@ -13051,6 +13155,12 @@ type BookingSliceKitAttribution = {
   sourceKitId: string | null;
   /** LIVE kit membership of this slice's asset (`Asset.assetKits`). */
   assetKits: { kitId: string }[];
+  /**
+   * Decides whether a slice carrying no provenance answers from that
+   * membership: only an `INDIVIDUAL` asset empties its kit by going out
+   * standalone.
+   */
+  assetType: AssetType;
 };
 
 /**
@@ -13070,17 +13180,15 @@ type BookingSliceKitAttribution = {
  * `assetKitId -> AssetKit.kitId` hop for rows written before that column. It
  * does NOT belong to its asset's other kits — the slice names its own.
  *
- * A standalone slice carries no provenance by design, so it belongs to its
- * asset's LIVE kits: the acquire paths stamp those CHECKED_OUT from membership
- * ({@link getKitIdsByAssets}), and a release gate that ignored them would let a
- * kit go AVAILABLE with a member's free-pool units still out. This is where the
- * union {@link getKitIdsByBookingSlices}'s callers perform by hand lives
- * instead — per slice, inside the resolver.
+ * A standalone slice carries no provenance by design, so it answers from its
+ * asset's LIVE kits — but only for an `INDIVIDUAL` asset, mirroring what
+ * {@link getKitIdsToAcquire} was willing to stamp. A standalone
+ * `QUANTITY_TRACKED` slice draws on the free pool and takes no kit's units, so
+ * it owes no kit anything on the way back. Release must be the exact inverse of
+ * acquire: gate on a kit acquire never stamped and it never comes back.
  *
- * EVERY live membership counts here, not just the first. `getKitIdsByAssets`
- * reads `assetKits[0]` alone, so the acquire side stamps one kit where an asset
- * sits in several. Taking all of them on the release side can only add
- * obligations, never drop one, and over-release is the worse failure.
+ * EVERY live membership counts, not just the first — `AssetKit` rows come back
+ * unordered, so a first-row read names an arbitrary kit and drops the rest.
  *
  * A sibling rather than a new shape for {@link getKitIdsByBookingSlices}: five
  * of its six callers read `.keys()` only, and both shapes are `Map<string,
@@ -13119,7 +13227,7 @@ export async function getKitIdsBySlice({
           ? kitIdByAssetKitId.get(slice.assetKitId)
           : undefined);
       if (kitId) kitIds.add(kitId);
-    } else {
+    } else if (slice.assetType === AssetType.INDIVIDUAL) {
       for (const membership of slice.assetKits ?? []) {
         if (membership?.kitId) kitIds.add(membership.kitId);
       }
@@ -13316,6 +13424,9 @@ export async function bulkDeleteBookings({
               asset: {
                 select: {
                   id: true,
+                  // `type` decides whether a standalone slice releases this
+                  // asset's kits — see `getKitIdsToAcquire`.
+                  type: true,
                   assetKits: { select: { kitId: true } },
                 },
               },
@@ -13337,15 +13448,6 @@ export async function bulkDeleteBookings({
     const overdueOrOngoingBookings = bookings.filter(
       (booking) => booking.status === "OVERDUE" || booking.status === "ONGOING"
     );
-
-    /**
-     * Resolved before the transaction opens: the legacy provenance hop is a
-     * read, and holding a transaction open across it buys nothing.
-     */
-    const bulkDeleteSliceKitIds = await getKitIdsByBookingSlices({
-      slices: overdueOrOngoingBookings.flatMap((b) => b.bookingAssets),
-      organizationId,
-    });
 
     /** We have to cancel scheduler for the bookings */
     const bookingsWithSchedulerReference = bookings.filter(
@@ -13369,10 +13471,13 @@ export async function bulkDeleteBookings({
 
         // Union of live membership and booking-slice provenance — a kit whose
         // member was detached mid-booking is invisible to membership alone.
-        const uniqueKitIds = new Set([
-          ...getKitIdsByAssets(allAssets),
-          ...bulkDeleteSliceKitIds.keys(),
-        ]);
+        // Release mirrors acquire — see the twin in `checkinBooking`.
+        const uniqueKitIds = new Set(
+          await getKitIdsToAcquire({
+            slices: overdueOrOngoingBookings.flatMap((b) => b.bookingAssets),
+            organizationId,
+          })
+        );
 
         /**
          * Per asset, never a blanket flip. An asset on one of these bookings
@@ -13395,6 +13500,7 @@ export async function bulkDeleteBookings({
         await releaseCheckedOutKits(tx, {
           kitIds: [...uniqueKitIds],
           organizationId,
+          excludeBookingIds: bookings.map((booking) => booking.id),
         });
       }
 
@@ -13717,6 +13823,9 @@ export async function bulkCancelBookings({
               asset: {
                 select: {
                   id: true,
+                  // `type` decides whether a standalone slice releases this
+                  // asset's kits — see `getKitIdsToAcquire`.
+                  type: true,
                   assetKits: { select: { kitId: true } },
                 },
               },
@@ -13765,15 +13874,6 @@ export async function bulkCancelBookings({
       (b) => b.status === "ONGOING" || b.status === "OVERDUE"
     );
 
-    /**
-     * Resolved before the transaction opens: the legacy provenance hop is a
-     * read, and holding a transaction open across it buys nothing.
-     */
-    const bulkCancelSliceKitIds = await getKitIdsByBookingSlices({
-      slices: ongoingOrOverdueBookings.flatMap((b) => b.bookingAssets),
-      organizationId,
-    });
-
     /** We have to cancel scheduler for the bookings */
     const bookingsWithSchedulerReference = bookings.filter(
       (booking) => !!booking.activeSchedulerReference
@@ -13793,10 +13893,13 @@ export async function bulkCancelBookings({
         );
         // Union of live membership and booking-slice provenance — a kit whose
         // member was detached mid-booking is invisible to membership alone.
-        const uniqueKitIds = new Set([
-          ...getKitIdsByAssets(allAssets),
-          ...bulkCancelSliceKitIds.keys(),
-        ]);
+        // Release mirrors acquire — see the twin in `checkinBooking`.
+        const uniqueKitIds = new Set(
+          await getKitIdsToAcquire({
+            slices: ongoingOrOverdueBookings.flatMap((b) => b.bookingAssets),
+            organizationId,
+          })
+        );
 
         /**
          * Per asset, never a blanket flip. An asset on one of these bookings
@@ -13820,6 +13923,7 @@ export async function bulkCancelBookings({
         await releaseCheckedOutKits(tx, {
           kitIds: [...uniqueKitIds],
           organizationId,
+          excludeBookingIds: bookings.map((b) => b.id),
         });
       }
 

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -887,20 +887,61 @@ async function releaseCheckedOutKits(
       // which is correct: some of its units are still out.
       checkedOutAt: { not: null },
       checkedInAt: null,
+      // The three shapes a slice can hold a kit through — the same three
+      // `getKitIdsToAcquire` stamps one from. Drop the last leg and a kit whose
+      // INDIVIDUAL member is out on a standalone slice reads as unheld, because
+      // that slice carries no provenance by design.
       OR: [
         { sourceKitId: { in: kitIds } },
         { assetKitId: { in: [...kitIdByAssetKitId.keys()] } },
+        {
+          sourceKitId: null,
+          assetKitId: null,
+          asset: {
+            type: AssetType.INDIVIDUAL,
+            assetKits: { some: { kitId: { in: kitIds }, organizationId } },
+          },
+        },
       ],
     },
-    select: { assetKitId: true, sourceKitId: true },
+    select: {
+      id: true,
+      assetKitId: true,
+      sourceKitId: true,
+      asset: {
+        select: { type: true, assetKits: { select: { kitId: true } } },
+      },
+    },
   });
 
+  // Attributed by the shared resolver rather than by hand: one implementation
+  // of "which kit does this slice hold" is what keeps acquire and release from
+  // drifting apart again.
+  const kitIdsBySliceId = await getKitIdsBySlice({
+    slices: slicesStillOut.map((slice) => ({
+      id: slice.id,
+      assetKitId: slice.assetKitId,
+      sourceKitId: slice.sourceKitId,
+      // Defensive `?.`, matching the other resolvers: fixtures and narrower
+      // selects can omit the relation. Without `asset` a slice answers from
+      // provenance alone, which is the safe direction — it can only fail to
+      // pin a kit this exit was already releasing.
+      assetKits: slice.asset?.assetKits ?? [],
+      assetType: slice.asset?.type,
+    })),
+    organizationId,
+    client,
+  });
+
+  // Intersected with the kits actually being released: a standalone slice's
+  // asset can belong to kits this exit knows nothing about, and those are not
+  // ours to pin.
+  const requestedKitIds = new Set(kitIds);
   const heldByAnotherBooking = new Set<string>();
-  for (const slice of slicesStillOut) {
-    const kitId =
-      slice.sourceKitId ??
-      (slice.assetKitId ? kitIdByAssetKitId.get(slice.assetKitId) : undefined);
-    if (kitId) heldByAnotherBooking.add(kitId);
+  for (const sliceKitIds of kitIdsBySliceId.values()) {
+    for (const kitId of sliceKitIds) {
+      if (requestedKitIds.has(kitId)) heldByAnotherBooking.add(kitId);
+    }
   }
 
   const releasableKitIds = kitIds.filter(
@@ -8361,10 +8402,24 @@ export async function partialCheckoutBooking({
         const untaggedQtySliceIds = bookingFound.bookingAssets
           .filter((ba) => untaggedQtyAssetIds.has(ba.asset.id))
           .map((ba) => ba.id);
+        /**
+         * Every slice of every kit this booking holds is read too, not just the
+         * ones this batch names. The kit-completeness test below asks what each
+         * of a kit's slices still owes, and an absent entry there would read as
+         * "owes nothing" — stamping a kit whose other member was never scanned.
+         *
+         * Free: the helper dedupes its id list and costs a fixed number of
+         * queries however long it is, so widening this call is what keeps the
+         * answer complete without a second round-trip.
+         */
+        const kitSliceIds = [...sliceIdsByKitId.values()].flatMap((ids) => [
+          ...ids,
+        ]);
         const sliceCommittedRemainingBySlice =
           await computeBookingAssetsSliceRemainingToCheckOut(tx, id, [
             ...sliceTaggedBookingAssetIds,
             ...untaggedQtySliceIds,
+            ...kitSliceIds,
           ]);
 
         for (const disp of dispositions) {
@@ -8863,20 +8918,23 @@ export async function partialCheckoutBooking({
          *
          * `sliceCommittedRemainingBySlice` is what each slice still owed before
          * this batch, so a slice already fully out enters at 0 and a slice this
-         * batch finishes lands there — no re-read needed, and the arithmetic is
-         * the same one the per-slice caps were enforced with.
+         * batch finishes lands there. What moved comes from `unitsBySliceId`,
+         * the same per-slice attribution the departure markers were written
+         * from — so the kit decision and the markers can never disagree, and
+         * INDIVIDUAL and untagged claims are counted, which the QT-only
+         * disposition ledger does not carry.
          */
-        const claimedThisBatch = (sliceId: string) =>
-          claimedBySliceThisBatch.get(sliceId) ?? 0;
+        const movedThisBatch = (sliceId: string) =>
+          unitsBySliceId.get(sliceId) ?? 0;
         const remainingAfterBatch = (sliceId: string) =>
           (sliceCommittedRemainingBySlice.get(sliceId) ?? 0) -
-          claimedThisBatch(sliceId);
+          movedThisBatch(sliceId);
 
         const completeKitIds: string[] = [];
         for (const [kitId, sliceIds] of sliceIdsByKitId) {
           const ids = [...sliceIds];
           // A kit none of whose slices moved keeps the status it had.
-          if (!ids.some((sliceId) => claimedThisBatch(sliceId) > 0)) continue;
+          if (!ids.some((sliceId) => movedThisBatch(sliceId) > 0)) continue;
           if (ids.every((sliceId) => remainingAfterBatch(sliceId) <= 0)) {
             completeKitIds.push(kitId);
           }

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -922,10 +922,11 @@ async function releaseCheckedOutKits(
       id: slice.id,
       assetKitId: slice.assetKitId,
       sourceKitId: slice.sourceKitId,
-      // Defensive `?.`, matching the other resolvers: fixtures and narrower
-      // selects can omit the relation. Without `asset` a slice answers from
-      // provenance alone, which is the safe direction — it can only fail to
-      // pin a kit this exit was already releasing.
+      // Defensive `?.` for fixtures and narrower selects, NOT because the
+      // fallback is harmless here: a slice that fails to pin its kit makes the
+      // kit MORE releasable, which is the direction this guard exists to
+      // prevent. The `select` above always projects `asset`, so the fallback is
+      // unreachable in production — keep it that way if this query is edited.
       assetKits: slice.asset?.assetKits ?? [],
       assetType: slice.asset?.type,
     })),

--- a/apps/webapp/app/modules/kit/service.server.test.ts
+++ b/apps/webapp/app/modules/kit/service.server.test.ts
@@ -26,6 +26,7 @@ import {
   relinkKitQrCode,
   getAvailableKitAssetForBooking,
   updateKitsWithBookingCustodians,
+  getKitCurrentBooking,
   bulkRemoveAssetsFromKits,
   moveAssetKitUnits,
 } from "./service.server";
@@ -1835,6 +1836,21 @@ describe("updateKitsWithBookingCustodians", () => {
     expect(result).toEqual(kits);
   });
 
+  /**
+   * A kit's holder comes from the booking that took THAT kit's slices, so the
+   * lookup is two queries: the kit's membership rows, then the booked slices
+   * pointing at them (or at the kit itself via `sourceKitId`).
+   */
+  function mockHoldingSlices(
+    memberships: { id: string; kitId: string }[],
+    slices: unknown[]
+  ) {
+    //@ts-expect-error missing vitest type
+    db.assetKit.findMany.mockResolvedValue(memberships);
+    //@ts-expect-error missing vitest type
+    db.bookingAsset.findMany.mockResolvedValue(slices);
+  }
+
   it("should resolve custodian from booking for checked-out kit", async () => {
     expect.assertions(2);
     const kits = [
@@ -1846,24 +1862,28 @@ describe("updateKitsWithBookingCustodians", () => {
       },
     ];
 
-    // why: simulating asset with active booking and custodian user
-    //@ts-expect-error missing vitest type
-    db.asset.findFirst.mockResolvedValue({
-      id: "asset-1",
-      bookingAssets: [
+    // why: simulating a slice booked under this kit, whose booking names a
+    // registered user as custodian.
+    mockHoldingSlices(
+      [{ id: "ak-1", kitId: "kit-co" }],
+      [
         {
+          assetKitId: "ak-1",
+          sourceKitId: null,
+          checkedOutAt: new Date("2026-09-01T09:00:00Z"),
+          checkedInAt: null,
           booking: {
-            id: "booking-1",
             custodianTeamMember: null,
             custodianUser: {
               firstName: "Jane",
               lastName: "Doe",
+              displayName: null,
               profilePicture: "pic.jpg",
             },
           },
         },
-      ],
-    });
+      ]
+    );
 
     const result = await updateKitsWithBookingCustodians(kits);
 
@@ -1873,17 +1893,19 @@ describe("updateKitsWithBookingCustodians", () => {
         user: {
           firstName: "Jane",
           lastName: "Doe",
+          displayName: null,
           profilePicture: "pic.jpg",
         },
       },
     });
-    expect(db.asset.findFirst).toHaveBeenCalledWith(
+    // Only slices booked under this kit are considered.
+    expect(db.bookingAsset.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
-          assetKits: { some: { kitId: "kit-co" } },
-          bookingAssets: {
-            some: { booking: { status: { in: ["ONGOING", "OVERDUE"] } } },
-          },
+          OR: [
+            { sourceKitId: { in: ["kit-co"] } },
+            { assetKitId: { in: ["ak-1"] } },
+          ],
         }),
       })
     );
@@ -1901,25 +1923,96 @@ describe("updateKitsWithBookingCustodians", () => {
     ];
 
     // why: simulating booking with team member custodian instead of user
-    //@ts-expect-error missing vitest type
-    db.asset.findFirst.mockResolvedValue({
-      id: "asset-1",
-      bookingAssets: [
+    mockHoldingSlices(
+      [{ id: "ak-1", kitId: "kit-co" }],
+      [
         {
+          assetKitId: "ak-1",
+          sourceKitId: null,
+          checkedOutAt: new Date("2026-09-01T09:00:00Z"),
+          checkedInAt: null,
           booking: {
-            id: "booking-1",
             custodianTeamMember: { name: "External Contractor" },
             custodianUser: null,
           },
         },
-      ],
-    });
+      ]
+    );
 
     const result = await updateKitsWithBookingCustodians(kits);
 
     expect((result[0] as any).custody).toEqual({
       custodian: { name: "External Contractor" },
     });
+  });
+
+  it("does not name a holder once this kit's slice has come back", async () => {
+    expect.assertions(1);
+    // The booking is still ONGOING because other assets are out; this kit's
+    // units are already back, so nobody is holding it.
+    const kits = [
+      {
+        ...mockKitData,
+        locationId: null,
+        id: "kit-co",
+        status: KitStatus.CHECKED_OUT,
+      },
+    ];
+
+    mockHoldingSlices(
+      [{ id: "ak-1", kitId: "kit-co" }],
+      [
+        {
+          assetKitId: "ak-1",
+          sourceKitId: null,
+          checkedOutAt: new Date("2026-09-01T09:00:00Z"),
+          checkedInAt: new Date("2026-09-02T09:00:00Z"),
+          booking: {
+            custodianTeamMember: { name: "Someone Else" },
+            custodianUser: null,
+          },
+        },
+      ]
+    );
+
+    const result = await updateKitsWithBookingCustodians(kits);
+
+    expect((result[0] as any).custody).toBeUndefined();
+  });
+
+  it("does not borrow the custodian of a booking that holds another kit", async () => {
+    expect.assertions(1);
+    // A QUANTITY_TRACKED asset sits in both kits. The live booking took it
+    // through kit-other's slice, so kit-co has no holder of its own and must
+    // not inherit that booking's custodian.
+    const kits = [
+      {
+        ...mockKitData,
+        locationId: null,
+        id: "kit-co",
+        status: KitStatus.CHECKED_OUT,
+      },
+    ];
+
+    mockHoldingSlices(
+      [{ id: "ak-mine", kitId: "kit-co" }],
+      [
+        {
+          assetKitId: "ak-other",
+          sourceKitId: "kit-other",
+          checkedOutAt: new Date("2026-09-01T09:00:00Z"),
+          checkedInAt: null,
+          booking: {
+            custodianTeamMember: { name: "Someone Else" },
+            custodianUser: null,
+          },
+        },
+      ]
+    );
+
+    const result = await updateKitsWithBookingCustodians(kits);
+
+    expect((result[0] as any).custody).toBeUndefined();
   });
 
   it("should handle kit with no asset having active booking gracefully", async () => {
@@ -1933,10 +2026,8 @@ describe("updateKitsWithBookingCustodians", () => {
       },
     ];
 
-    // why: reproducing the Sentry error scenario where findFirst returns null
-    // because no asset in the kit has an ONGOING/OVERDUE booking
-    //@ts-expect-error missing vitest type
-    db.asset.findFirst.mockResolvedValue(null);
+    // why: no booked slice points at this kit, so nothing can name a holder.
+    mockHoldingSlices([{ id: "ak-1", kitId: "kit-co" }], []);
 
     const result = await updateKitsWithBookingCustodians(kits);
 
@@ -1944,6 +2035,170 @@ describe("updateKitsWithBookingCustodians", () => {
     expect(result[0]).toEqual(kits[0]);
     // Should not throw
     expect(result).toHaveLength(1);
+  });
+});
+
+describe("getKitCurrentBooking", () => {
+  // The whole `CurrentBookingType` shape, so these fixtures typecheck against
+  // the helper's return. `status` is widened off the literal so the completed
+  // case below can reuse it; the custodian fields are irrelevant here — the
+  // scoping tests assert on WHICH booking comes back, not on who holds it.
+  const ongoing = {
+    id: "booking-1",
+    name: "Field trip",
+    status: BookingStatus.ONGOING as BookingStatus,
+    from: new Date("2026-09-01T08:00:00Z"),
+    custodianUser: null,
+    custodianTeamMember: null,
+  };
+
+  const wentOut = new Date("2026-09-01T09:00:00Z");
+
+  /**
+   * One membership row of the kit under test, with its asset's booked slices.
+   * A slice defaults to "still out" — the case every scoping test is about.
+   */
+  function membership(
+    id: string,
+    slices: {
+      assetKitId: string | null;
+      sourceKitId: string | null;
+      checkedOutAt?: Date | null;
+      checkedInAt?: Date | null;
+      booking?: typeof ongoing;
+    }[]
+  ) {
+    return {
+      id,
+      asset: {
+        bookingAssets: slices.map((slice) => ({
+          ...slice,
+          checkedOutAt:
+            slice.checkedOutAt === undefined ? wentOut : slice.checkedOutAt,
+          checkedInAt: slice.checkedInAt ?? null,
+          booking: slice.booking ?? ongoing,
+        })),
+      },
+    };
+  }
+
+  it("returns the booking that took this kit's slice", () => {
+    const result = getKitCurrentBooking({
+      id: "kit-1",
+      assetKits: [
+        membership("ak-1", [{ assetKitId: "ak-1", sourceKitId: "kit-1" }]),
+      ],
+    });
+
+    expect(result).toEqual(ongoing);
+  });
+
+  it("resolves a slice whose membership row is gone, via sourceKitId", () => {
+    const result = getKitCurrentBooking({
+      id: "kit-1",
+      assetKits: [membership("ak-1", [{ assetKitId: null, sourceKitId: "kit-1" }])],
+    });
+
+    expect(result).toEqual(ongoing);
+  });
+
+  it("ignores a booking that took the shared asset through another kit", () => {
+    // The asset is in kit-1 and kit-2; this booking holds kit-2's slice.
+    const result = getKitCurrentBooking({
+      id: "kit-1",
+      assetKits: [
+        membership("ak-1", [{ assetKitId: "ak-2", sourceKitId: "kit-2" }]),
+      ],
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("ignores a standalone slice of a kit member", () => {
+    // Free-pool units leave the kit's own slice untouched.
+    const result = getKitCurrentBooking({
+      id: "kit-1",
+      assetKits: [membership("ak-1", [{ assetKitId: null, sourceKitId: null }])],
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("ignores a slice this kit already got back, on a still-ongoing booking", () => {
+    // The booking stays ONGOING because other assets are still out; this kit's
+    // units came back, so it is not being held by anyone.
+    const result = getKitCurrentBooking({
+      id: "kit-1",
+      assetKits: [
+        membership("ak-1", [
+          {
+            assetKitId: "ak-1",
+            sourceKitId: "kit-1",
+            checkedOutAt: wentOut,
+            checkedInAt: new Date("2026-09-02T09:00:00Z"),
+          },
+        ]),
+      ],
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("treats a slice with no departure markers as out", () => {
+    // Rows written before the markers existed carry neither. On a booking that
+    // is still ONGOING they are out, and reading the blank as "already back"
+    // would drop the holder from every pre-existing booking.
+    const result = getKitCurrentBooking({
+      id: "kit-1",
+      assetKits: [
+        membership("ak-1", [
+          {
+            assetKitId: "ak-1",
+            sourceKitId: "kit-1",
+            checkedOutAt: null,
+            checkedInAt: null,
+          },
+        ]),
+      ],
+    });
+
+    expect(result).toEqual(ongoing);
+  });
+
+  it("still holds a slice that came back and then went out again", () => {
+    // Both markers are set; the refreshed departure is the later one.
+    const result = getKitCurrentBooking({
+      id: "kit-1",
+      assetKits: [
+        membership("ak-1", [
+          {
+            assetKitId: "ak-1",
+            sourceKitId: "kit-1",
+            checkedOutAt: new Date("2026-09-03T09:00:00Z"),
+            checkedInAt: new Date("2026-09-02T09:00:00Z"),
+          },
+        ]),
+      ],
+    });
+
+    expect(result).toEqual(ongoing);
+  });
+
+  it("ignores slices whose booking is no longer live", () => {
+    const result = getKitCurrentBooking({
+      id: "kit-1",
+      assetKits: [
+        membership("ak-1", [
+          {
+            assetKitId: "ak-1",
+            sourceKitId: "kit-1",
+            booking: { ...ongoing, status: BookingStatus.COMPLETE },
+          },
+        ]),
+      ],
+    });
+
+    expect(result).toBeUndefined();
   });
 });
 

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -2610,68 +2610,196 @@ export async function releaseCustody({
   }
 }
 
+/**
+ * Whether a booked slice is out right now.
+ *
+ * Read from the slice's own markers rather than `Asset.status`, which says the
+ * asset is out SOMEWHERE — true of a `QUANTITY_TRACKED` asset whichever kit
+ * took it. A live booking is not enough either: one stays ONGOING while other
+ * assets are away, long after this slice came back.
+ *
+ * A returning slice is the only thing that clears it, so absence of
+ * `checkedOutAt` is not evidence of absence: rows written before the markers
+ * existed carry neither, and read as out — which is what they are, on a booking
+ * still ONGOING. When the departure IS recorded, the check-in has to be no
+ * older than the departure it answers: a slice that came back and then went out
+ * again carries both, and the refreshed `checkedOutAt` is what says it is out
+ * now.
+ */
+function isSliceStillOut(slice: {
+  checkedOutAt: Date | null;
+  checkedInAt: Date | null;
+}): boolean {
+  if (!slice.checkedInAt) return true;
+  return slice.checkedOutAt !== null && slice.checkedInAt < slice.checkedOutAt;
+}
+
+/** The custodian of a booking, projected for a kit row's custody cell. */
+type KitBookingCustodian = {
+  custodianUser: Pick<
+    User,
+    "firstName" | "lastName" | "displayName" | "profilePicture"
+  > | null;
+  custodianTeamMember: { name: string } | null;
+};
+
+/**
+ * Resolves, for each of `kitIds`, the booking that currently holds THAT kit.
+ *
+ * A booked slice belongs to a kit when it was booked under one of the kit's
+ * live membership rows (`BookingAsset.assetKitId` → `AssetKit.id`) or under the
+ * kit itself (`BookingAsset.sourceKitId`, which survives a detach). Both
+ * columns are NULL on a standalone free-pool slice.
+ *
+ * That scoping is what makes the answer correct for `QUANTITY_TRACKED` assets:
+ * one asset may sit in several kits at once, so "this asset is on an ongoing
+ * booking" says nothing about which kit that booking took.
+ *
+ * Costs two round-trips whatever the number of kits — the membership ids, then
+ * the slices — so a page of checked-out kits does not fan out per row.
+ *
+ * @param kitIds - The kits to resolve, typically one page's checked-out rows
+ * @returns Kit id → the holding booking's custodian, for kits that have one
+ */
+async function getBookingCustodiansHoldingKits(
+  kitIds: Kit["id"][],
+  organizationIds: Kit["organizationId"][]
+): Promise<Map<Kit["id"], KitBookingCustodian>> {
+  const membershipRows = await db.assetKit.findMany({
+    where: { kitId: { in: kitIds }, organizationId: { in: organizationIds } },
+    select: { id: true, kitId: true },
+  });
+  const kitIdByAssetKitId = new Map(
+    membershipRows.map((row) => [row.id, row.kitId])
+  );
+
+  const bookedSlices = await db.bookingAsset.findMany({
+    where: {
+      booking: {
+        status: { in: [BookingStatus.ONGOING, BookingStatus.OVERDUE] },
+        organizationId: { in: organizationIds },
+      },
+      OR: [
+        { sourceKitId: { in: kitIds } },
+        { assetKitId: { in: [...kitIdByAssetKitId.keys()] } },
+      ],
+    },
+    // Several ongoing bookings can hold one kit at once. Ordering fixes which
+    // of them names the custodian, so the cell does not flip between requests
+    // with whatever order Postgres happens to return.
+    orderBy: { id: "asc" },
+    select: {
+      assetKitId: true,
+      sourceKitId: true,
+      // Departure markers. A booking stays ONGOING while other assets are
+      // away, so its status alone does not say this kit's units are still out.
+      // The comparison between the two is a column-to-column one that a Prisma
+      // `where` cannot express, so it is applied below.
+      checkedOutAt: true,
+      checkedInAt: true,
+      booking: {
+        select: {
+          custodianTeamMember: { select: { name: true } },
+          custodianUser: {
+            select: {
+              firstName: true,
+              lastName: true,
+              displayName: true,
+              profilePicture: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const requestedKitIds = new Set(kitIds);
+  const custodianByKitId = new Map<Kit["id"], KitBookingCustodian>();
+
+  for (const slice of bookedSlices) {
+    if (!isSliceStillOut(slice)) continue;
+
+    // Live membership names the kit exactly; `sourceKitId` answers for slices
+    // whose membership row has since been removed.
+    const kitId =
+      (slice.assetKitId ? kitIdByAssetKitId.get(slice.assetKitId) : null) ??
+      slice.sourceKitId;
+
+    if (!kitId || !requestedKitIds.has(kitId) || custodianByKitId.has(kitId)) {
+      continue;
+    }
+
+    custodianByKitId.set(kitId, slice.booking);
+  }
+
+  return custodianByKitId;
+}
+
+/**
+ * Whether a kit row's projection already names a custodian of its own.
+ *
+ * `Kit` declares no `custody` field — it arrives through whatever `include` the
+ * caller asked for, so its presence is a fact about the projection rather than
+ * the model. Probing structurally reads it without widening the generic that
+ * every call site is bound to.
+ */
+function kitCarriesOwnCustodian(kit: Kit): boolean {
+  const custody = (kit as { custody?: { custodian?: unknown } | null }).custody;
+  return Boolean(custody?.custodian);
+}
+
+/**
+ * Fills a CHECKED_OUT kit's custody cell with the custodian of the booking
+ * holding it.
+ *
+ * A kit has no direct relation to a booking: it goes out through the slices its
+ * member assets contribute, so the custodian is read back from the booking
+ * those slices belong to — and only slices booked under this kit count, see
+ * {@link getBookingCustodiansHoldingKits}. A kit no booking holds keeps
+ * whatever custodian its own `custody` row names.
+ *
+ * Kits in any other status are returned untouched, by reference.
+ *
+ * @param kits - Kit rows to annotate; every other field is preserved as-is
+ * @returns The same rows, with booking custody filled in where one applies
+ * @throws {ShelfError} If the custodian lookup fails
+ */
 export async function updateKitsWithBookingCustodians<T extends Kit>(
   kits: T[]
 ): Promise<T[]> {
   try {
     /** When kits are checked out, we have to display the custodian from that booking */
-    const checkedOutKits = kits
-      .filter((kit) => kit.status === "CHECKED_OUT")
-      .map((k) => k.id);
+    const checkedOutKitIds = kits
+      .filter((kit) => kit.status === KitStatus.CHECKED_OUT)
+      .map((kit) => kit.id);
 
-    if (checkedOutKits.length === 0) {
+    if (checkedOutKitIds.length === 0) {
       return kits;
     }
 
-    const resolvedKits: T[] = [];
+    // Org scope comes off the rows themselves — every `Kit` carries it — so the
+    // lookup cannot reach another workspace without widening the signature
+    // every call site is bound to.
+    const organizationIds = [
+      ...new Set(kits.map((kit) => kit.organizationId)),
+    ];
+    const custodianByKitId = await getBookingCustodiansHoldingKits(
+      checkedOutKitIds,
+      organizationIds
+    );
+    const checkedOutKitIdSet = new Set(checkedOutKitIds);
 
-    for (const kit of kits) {
-      if (!checkedOutKits.includes(kit.id)) {
-        resolvedKits.push(kit);
-        continue;
+    return kits.map((kit): T => {
+      if (!checkedOutKitIdSet.has(kit.id)) {
+        return kit;
       }
 
-      /** A kit is not directly associated with booking so have to make an extra query to get the booking for kit.
-       * We filter for assets that have an active booking to avoid picking
-       * an asset in the kit that is AVAILABLE and has no relevant booking.
-       * Kit membership is read through the `AssetKit` pivot. */
-      const kitAsset = await db.asset.findFirst({
-        where: {
-          assetKits: { some: { kitId: kit.id } },
-          bookingAssets: {
-            some: { booking: { status: { in: ["ONGOING", "OVERDUE"] } } },
-          },
-        },
-        select: {
-          id: true,
-          bookingAssets: {
-            where: { booking: { status: { in: ["ONGOING", "OVERDUE"] } } },
-            include: {
-              booking: {
-                select: {
-                  id: true,
-                  custodianTeamMember: true,
-                  custodianUser: {
-                    select: {
-                      firstName: true,
-                      lastName: true,
-                      displayName: true,
-                      profilePicture: true,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      });
-
-      const booking = kitAsset?.bookingAssets[0]?.booking;
-      const custodianUser = booking?.custodianUser;
-      const custodianTeamMember = booking?.custodianTeamMember;
+      const holdingCustodian = custodianByKitId.get(kit.id);
+      const custodianUser = holdingCustodian?.custodianUser;
+      const custodianTeamMember = holdingCustodian?.custodianTeamMember;
 
       if (custodianUser) {
-        resolvedKits.push({
+        return {
           ...kit,
           custody: {
             custodian: {
@@ -2682,17 +2810,20 @@ export async function updateKitsWithBookingCustodians<T extends Kit>(
               user: custodianUser,
             },
           },
-        });
-      } else if (custodianTeamMember) {
-        resolvedKits.push({
+        };
+      }
+
+      if (custodianTeamMember) {
+        return {
           ...kit,
-          custody: {
-            custodian: { name: custodianTeamMember.name },
-          },
-        });
-      } else {
-        resolvedKits.push(kit);
-        /** This case should never happen because there must be a custodianUser or custodianTeamMember assigned to a booking */
+          custody: { custodian: { name: custodianTeamMember.name } },
+        };
+      }
+
+      // A booking always names a custodian, so reaching here means no booking
+      // holds this kit's slices. The kit's own custody row is then the only
+      // holder there is — and when that is empty too, nothing can name one.
+      if (!kitCarriesOwnCustodian(kit)) {
         Logger.error(
           new ShelfError({
             cause: null,
@@ -2702,9 +2833,9 @@ export async function updateKitsWithBookingCustodians<T extends Kit>(
           })
         );
       }
-    }
 
-    return resolvedKits;
+      return kit;
+    });
   } catch (cause) {
     throw new ShelfError({
       cause,
@@ -2728,43 +2859,61 @@ type CurrentBookingType = {
 };
 
 /**
- * Determines if a kit has a current booking by checking its assets.
- * A kit is considered to have a current booking when at least one of its assets is:
- * 1. Currently checked out (status === CHECKED_OUT)
- * 2. Has an ongoing or overdue booking
+ * The ongoing or overdue booking that currently holds a kit, if any.
  *
- * This ensures the custody card only shows when assets are actually in custody,
- * not just when they have ongoing bookings but have been checked back in.
+ * A kit goes out through the booking slices its member assets contribute, and
+ * only slices booked under THIS kit count: `BookingAsset.assetKitId` names one
+ * of the kit's live membership rows, and `sourceKitId` names the kit itself and
+ * survives a detach. Both are NULL on a standalone free-pool slice.
  *
- * @returns The first ongoing/overdue booking found, or undefined if none exist
+ * The slice must also still be out — see {@link isSliceStillOut}.
+ *
+ * @param kit - The kit with its membership rows and their assets' active slices
+ * @returns The booking holding a slice of this kit that is still out, or
+ *   `undefined`
  */
 export function getKitCurrentBooking(kit: {
   id: string;
-  assets: {
-    status: AssetStatus;
-    bookingAssets: { booking: CurrentBookingType }[];
+  assetKits: {
+    id: string;
+    asset: {
+      bookingAssets: {
+        assetKitId: string | null;
+        sourceKitId: string | null;
+        checkedOutAt: Date | null;
+        checkedInAt: Date | null;
+        booking: CurrentBookingType;
+      }[];
+    };
   }[];
-}) {
-  const ongoingBookingAsset = kit.assets
-    // Filter each asset's bookingAssets to only ongoing or overdue ones
-    .map((a) => ({
-      ...a,
-      bookingAssets: a.bookingAssets.filter(
-        (ba) =>
-          ba.booking.status === BookingStatus.ONGOING ||
-          ba.booking.status === BookingStatus.OVERDUE
-      ),
-    }))
-    // Only consider assets that are actually checked out
-    .filter((a) => a.status === AssetStatus.CHECKED_OUT)
-    // Find the first asset that has any ongoing/overdue bookings
-    .find((a) => a.bookingAssets.length > 0);
+}): CurrentBookingType | undefined {
+  const ownAssetKitIds = new Set(
+    kit.assetKits.map((membership) => membership.id)
+  );
 
-  const ongoingBooking = ongoingBookingAsset
-    ? ongoingBookingAsset.bookingAssets[0].booking
-    : undefined;
+  /** Whether this slice was booked under the kit being asked about. */
+  const belongsToKit = (slice: {
+    assetKitId: string | null;
+    sourceKitId: string | null;
+  }) =>
+    slice.sourceKitId === kit.id ||
+    (slice.assetKitId !== null && ownAssetKitIds.has(slice.assetKitId));
 
-  return ongoingBooking;
+  for (const membership of kit.assetKits) {
+    const holdingSlice = membership.asset.bookingAssets.find(
+      (slice) =>
+        (slice.booking.status === BookingStatus.ONGOING ||
+          slice.booking.status === BookingStatus.OVERDUE) &&
+        belongsToKit(slice) &&
+        isSliceStillOut(slice)
+    );
+
+    if (holdingSlice) {
+      return holdingSlice.booking;
+    }
+  }
+
+  return undefined;
 }
 
 export async function bulkDeleteKits({

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
@@ -80,7 +80,7 @@ import { buildAddToActiveBookingBlockerWhere } from "~/modules/booking/helpers";
 import {
   getBooking,
   getDetailedPartialCheckinData,
-  getKitIdsByAssets,
+  getKitIdsByBookingSlices,
   removeAssets,
   updateBookingAssets,
 } from "~/modules/booking/service.server";
@@ -338,9 +338,19 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       });
     }
 
-    const bookingKitIds = getKitIdsByAssets(
-      booking.bookingAssets.map((ba) => ba.asset)
-    );
+    /**
+     * The kits this booking holds, from the slices booked under them — see the
+     * twin in the manage-kits loader. Membership would count a kit whose
+     * `QUANTITY_TRACKED` member is only on the booking as a standalone slice.
+     */
+    const bookingKitIds = [
+      ...(
+        await getKitIdsByBookingSlices({
+          slices: booking.bookingAssets,
+          organizationId,
+        })
+      ).keys(),
+    ];
 
     /**
      * Strip kit-driven slices from `booking.bookingAssets` so the picker's

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
@@ -64,7 +64,7 @@ import type { KitSliceSpec } from "~/modules/booking/service.server";
 import {
   getBooking,
   getDetailedPartialCheckinData,
-  getKitIdsByAssets,
+  getKitIdsByBookingSlices,
   removeAssets,
   updateBookingAssets,
   createKitBookingNote,
@@ -199,9 +199,23 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       });
     }
 
-    const bookingKitIds = getKitIdsByAssets(
-      booking.bookingAssets.map((ba) => ba.asset)
-    );
+    /**
+     * The kits this booking holds, from the slices booked under them.
+     *
+     * Not from member assets' kit memberships: a `QUANTITY_TRACKED` asset can
+     * belong to several kits, so a standalone slice of one would pre-select a
+     * kit nobody added — and saving would then add it for real. The booking's
+     * own rows name the kit they were booked under, which is the same source
+     * `BOOKING_WITH_ASSETS_INCLUDE` groups the overview by.
+     */
+    const bookingKitIds = [
+      ...(
+        await getKitIdsByBookingSlices({
+          slices: booking.bookingAssets,
+          organizationId,
+        })
+      ).keys(),
+    ];
 
     /**
      * Book-by-Model — Models tab payload. Shared with the manage-assets

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.tsx
@@ -111,6 +111,11 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         extraInclude: {
           assetKits: {
             select: {
+              // The membership id is the kit-slice discriminator booked rows
+              // point at (`BookingAsset.assetKitId`). `getKitCurrentBooking`
+              // needs it to tell a booking that took THIS kit from one that
+              // took the same pooled asset through another kit.
+              id: true,
               asset: {
                 select: {
                   id: true,
@@ -127,6 +132,19 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
                       },
                     },
                     select: {
+                      // Kit provenance of the booked slice: `assetKitId` is
+                      // the live membership row it was booked under,
+                      // `sourceKitId` the kit itself, which outlives a detach.
+                      // Both NULL = a standalone free-pool slice that belongs
+                      // to no kit.
+                      assetKitId: true,
+                      sourceKitId: true,
+                      // Per-slice departure markers — the record of whether
+                      // these units are out right now. A booking stays ONGOING
+                      // while other assets are away, so its status alone does
+                      // not say this kit is still gone.
+                      checkedOutAt: true,
+                      checkedInAt: true,
                       booking: {
                         select: {
                           id: true,
@@ -200,7 +218,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     });
     const currentBooking = getKitCurrentBooking({
       id: kit.id,
-      assets: kit.assetKits.map((ak) => ak.asset),
+      assetKits: kit.assetKits,
     });
 
     const header: HeaderData = {

--- a/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.overview.manage-assets.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.overview.manage-assets.test.ts
@@ -45,7 +45,7 @@ vi.mock("~/modules/booking/service.server", () => ({
   removeAssets: vi.fn(),
   // Loader-only — used by the F2 loader tests below.
   getBooking: vi.fn(),
-  getKitIdsByAssets: vi.fn(),
+  getKitIdsByBookingSlices: vi.fn(),
 }));
 
 // Loader-only — `getPaginatedAndFilterableAssets` backs the Assets tab list.
@@ -1198,7 +1198,9 @@ describe("manage-assets loader — Models tab payload", () => {
       mockPaginatedAssets as any
     );
     vi.mocked(bookingService.getBooking).mockResolvedValue(mockLoaderBooking);
-    vi.mocked(bookingService.getKitIdsByAssets).mockReturnValue([]);
+    vi.mocked(bookingService.getKitIdsByBookingSlices).mockResolvedValue(
+      new Map()
+    );
     vi.mocked(modelRequestService.getBookingModelTabData).mockResolvedValue(
       mockModelTabData as any
     );

--- a/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.overview.manage-kits.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.overview.manage-kits.test.ts
@@ -39,7 +39,7 @@ vi.mock("~/modules/booking/service.server", () => ({
   createKitBookingNote: vi.fn(),
   // Loader-only — used by the Models-tab loader tests below.
   getBooking: vi.fn(),
-  getKitIdsByAssets: vi.fn(),
+  getKitIdsByBookingSlices: vi.fn(),
 }));
 
 // Loader-only — `getPaginatedAndFilterableKits` backs the Kits tab list.
@@ -923,7 +923,9 @@ describe("manage-kits loader — Models tab payload", () => {
     });
 
     vi.mocked(bookingService.getBooking).mockResolvedValue(mockLoaderBooking);
-    vi.mocked(bookingService.getKitIdsByAssets).mockReturnValue([]);
+    vi.mocked(bookingService.getKitIdsByBookingSlices).mockResolvedValue(
+      new Map()
+    );
     vi.mocked(kitService.getPaginatedAndFilterableKits).mockResolvedValue(
       mockPaginatedKits as any
     );


### PR DESCRIPTION
## The report

A customer on `/kits` (UIW – Communication Arts):

> After a custodian takes custody of a kit it is showing them having custody of multiple kits when this is not the case. These kits do utilize quantity tracked assets.

## Root cause

Not the custody flow — **check-out**. `getKitIdsByAssets` answered *"which kits did this booking take?"* from each asset's **first** pivot row:

```ts
assets.map((a) => a.assetKits?.[0]?.kitId)
```

That was correct when written: `266425e39` replaced `Asset.kitId` with the `AssetKit` pivot and kept `@@unique([assetId])`, so an asset had at most one kit. Migration `20260514100000_drop_asset_kit_unique_add_triggers` then dropped that unique and replaced it with `enforce_individual_asset_single_kit`, which caps **INDIVIDUAL** assets only — `QUANTITY_TRACKED` assets have been free to sit in several kits ever since. The helper was never revisited. No `assetKits` select in the file carries an `orderBy`, so `[0]` is whichever row Postgres returns.

Three defects, one visible symptom:

1. **Arbitrary kit.** A booking taking a shared QT asset from kit A could stamp **kit B** `CHECKED_OUT` and leave A untouched. Check-in re-derived the list the same way, so a different row order left the wrong kit stuck `CHECKED_OUT` with nothing out.
2. **Standalone slices stamped kits.** `checkoutBooking` passed *every* slice, including free-pool ones (`assetKitId == null`). Booking 5 loose units of a QT asset that happens to be a kit member marked that kit `CHECKED_OUT` though the kit's own slice never moved.
3. **Unscoped custodian lookup.** `updateKitsWithBookingCustodians` (kits index) and `getKitCurrentBooking` (kit detail) picked a booking off *any* member asset with no kit scoping, so even a legitimately checked-out kit could be labelled with the custodian of a different booking holding a shared QT member.

The kits index paints the holding booking's custodian onto any `CHECKED_OUT` kit — which is exactly "showing them having custody of multiple kits".

This is not cosmetic: `CHECKED_OUT` blocks bulk custody assign and booking adds.

## The fix

Kits are resolved from the **slice**, not from the asset's membership, with a type-aware rule for slices that carry no provenance:

| Slice | Kits it stamps |
| --- | --- |
| kit-driven (`sourceKitId` / `assetKitId`) | exactly the kit it was booked under |
| standalone, `INDIVIDUAL` | the asset's live kits — the one physical item left |
| standalone, `QUANTITY_TRACKED` | none — it draws on the free pool, a separate axis from the kit slices |

New `getKitIdsToAcquireBySlice` / `getKitIdsToAcquire` in `modules/booking/service.server.ts`, wired into `checkoutBooking`, `fulfilModelRequestsAndCheckout` and `partialCheckoutBooking`. They sit beside the existing release-side resolvers and reuse the same `resolveKitIdByAssetKitId` hop.

Both custodian displays are scoped the same way and additionally require the slice to **still be out**, read from its own `checkedOutAt` / `checkedInAt` markers per `.claude/rules/booking-checkout-is-recorded-per-slice.md` — a booking stays `ONGOING` while other assets are away, long after this kit's units came back. A slice carrying **neither** marker reads as out, so bookings predating #2951 keep their custodian.

### Adjacent defects fixed by the same change

- **Kit releases now scope to `status: CHECKED_OUT`.** The kit-id sets reaching those writes are deliberately over-inclusive, so a booking sharing a QT member with an unrelated kit could reset that kit to `AVAILABLE` while its `KitCustody` row survived — leaving `status = AVAILABLE` with a custodian still attached. All seven release sites go through one guarded `releaseCheckedOutKits` helper.
- **The booking pickers** (`manage-kits`, `manage-assets`) no longer pre-select a kit that is on the booking only through a member's standalone slice — the "extra kit nobody added" case. They now read the kits from the booking's own slices, the same source `BOOKING_WITH_ASSETS_INCLUDE` already groups the overview by.
- `getKitIdsByAssets` survives as a **release-only** leg and now returns every membership rather than the first, so no kit is left stranded on the way back.

### Performance

The kits index custodian lookup went from one `findFirst` per checked-out row to two queries per page.

## Tests

`pnpm webapp:validate` passes: **448 files, 5944 tests**, typecheck and lint clean.

New coverage:
- `getKitIdsToAcquire` — kit-driven slice resolves to its own kit; membership order does not affect the result; standalone QT stamps nothing; standalone INDIVIDUAL still stamps; the legacy `assetKitId` hop; a kit slice and a free-pool slice of the same asset on one booking stay apart.
- `updateKitsWithBookingCustodians` — does not borrow the custodian of a booking holding another kit; does not name a holder once this kit's slice is back.
- `getKitCurrentBooking` — five cases covering slice scoping, the returned/re-departed markers, and the legacy both-NULL row.

## Not in this PR

Kits already stranded `CHECKED_OUT` in production **will not self-heal**. A read-only diagnostic query is ready to hand over; it flags `has_kit_custody_row` so kits that should become `IN_CUSTODY` rather than `AVAILABLE` are not lumped in. No migration, no DDL.

## Reviewer note

Treating a standalone `QUANTITY_TRACKED` booking as *not* checking out the kit is a deliberate semantics change. The prior behaviour was documented as intentional in `getKitIdsBySlice`'s JSDoc, but it is what produces the customer's report, and it matches how the codebase already separates the kit axis from the free pool (`enforce_asset_location_sum_within_total`, `buildKitCustodyInheritData`). Worth a second opinion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved kit tracking during checkout, check-in, cancellation, deletion, and asset removal.
  - Kits are released only when no other active booking still holds them.
  - Partial checkout now updates kit status only after all required kit members are checked out.
  - Improved handling of standalone items and assets belonging to multiple kits.
  - Booking and kit management views now identify kits from recorded booking activity.
  - Kit custodians and current bookings are resolved more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->