### PR TITLE
fix(assets): end the availability bar where the asset was checked in

### DIFF
--- a/apps/webapp/app/components/assets/assets-index/use-asset-availability-data.test.ts
+++ b/apps/webapp/app/components/assets/assets-index/use-asset-availability-data.test.ts
@@ -392,8 +392,10 @@ describe("useAssetAvailabilityData — returned slices", () => {
   const BACK = "2026-07-10T15:30:00.000Z";
   // Bar start/end go through the same zone formatter as every bar today
   // (`useHints` is pinned to UTC above), so compare against its output.
+  /** Formats an instant the way the hook formats bar bounds. */
   const iso = (d: string) => toIsoDateTimeToUserTimezone(d, "UTC");
 
+  /** An ONGOING three-day booking row, with per-slice overrides. */
   const ongoing = (overrides: Partial<AdvancedAssetBooking> = {}) =>
     makeBooking({
       id: "b1",
@@ -404,6 +406,7 @@ describe("useAssetAvailabilityData — returned slices", () => {
       ...overrides,
     });
 
+  /** Renders the hook for one asset and returns its single event. */
   const eventFor = (items: unknown) => {
     const { result } = renderHook(() =>
       useAssetAvailabilityData(items as Items)

--- a/apps/webapp/app/components/assets/assets-index/use-asset-availability-data.test.ts
+++ b/apps/webapp/app/components/assets/assets-index/use-asset-availability-data.test.ts
@@ -8,10 +8,9 @@
  *   - Advanced mode (`query.server.ts` raw SQL) aggregates the pivot into a
  *     flat `asset.bookings: AdvancedAssetBooking[]`.
  *
- * The quantities pivot updated the hook + simple loader to the `bookingAssets`
- * shape but left advanced mode on `bookings`, so advanced-mode availability
- * rendered the asset rows but produced zero booking events. These tests lock in
- * that BOTH shapes yield events.
+ * Both loader shapes must yield the same events. These tests lock that in for
+ * the simple `bookingAssets` shape and the advanced `bookings` shape, and
+ * cover the returned-slice rule that ends a bar at the asset's check-in.
  *
  * @see {@link file://./use-asset-availability-data.ts}
  */
@@ -19,7 +18,14 @@ import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { AdvancedAssetBooking } from "~/modules/asset/types";
-import { useAssetAvailabilityData } from "./use-asset-availability-data";
+import { toIsoDateTimeToUserTimezone } from "~/utils/date-fns";
+import { userHasCustodyViewPermission } from "~/utils/permissions/custody-and-bookings-permissions.validator.client";
+import {
+  isSliceReturned,
+  resolveReturnedAt,
+  returnedBarEnd,
+  useAssetAvailabilityData,
+} from "./use-asset-availability-data";
 
 // why: useUserRoleHelper resolves roles via Remix loader data; tests do not
 // run inside a route, so stub it to a single-role admin set.
@@ -40,11 +46,12 @@ vi.mock("~/utils/client-hints", () => ({
 }));
 
 // why: custody-view gating is orthogonal to this hook's shape-normalization;
-// force it off so event titles stay the plain booking name.
+// default it off so event titles stay the plain booking name. A `vi.fn` so
+// the one title-order case below can switch it on for a single render.
 vi.mock(
   "~/utils/permissions/custody-and-bookings-permissions.validator.client",
   () => ({
-    userHasCustodyViewPermission: () => false,
+    userHasCustodyViewPermission: vi.fn(() => false),
   })
 );
 
@@ -368,5 +375,320 @@ describe("useAssetAvailabilityData", () => {
     // INDIVIDUAL asset booked via a kit → quantityTracked false, so the
     // renderer suppresses the redundant "Qty 1".
     expect(byResource.get("asset-ind")?.quantityTracked).toBe(false);
+  });
+});
+
+/**
+ * Returned slices: an asset checked in from a live booking is free again, so
+ * its bar must stop at the check-in instead of running to the booking's end.
+ * The rule reads the per-slice BookingAsset markers, never the booking status
+ * alone, and guards against the stale check-in marker the check-in backfill
+ * can leave on a row.
+ */
+describe("useAssetAvailabilityData — returned slices", () => {
+  const FROM = "2026-07-10T09:00:00.000Z";
+  const TO = "2026-07-13T17:00:00.000Z";
+  const OUT = "2026-07-10T09:05:00.000Z";
+  const BACK = "2026-07-10T15:30:00.000Z";
+  // Bar start/end go through the same zone formatter as every bar today
+  // (`useHints` is pinned to UTC above), so compare against its output.
+  const iso = (d: string) => toIsoDateTimeToUserTimezone(d, "UTC");
+
+  const ongoing = (overrides: Partial<AdvancedAssetBooking> = {}) =>
+    makeBooking({
+      id: "b1",
+      name: "Event",
+      status: "ONGOING",
+      from: FROM,
+      to: TO,
+      ...overrides,
+    });
+
+  const eventFor = (items: unknown) => {
+    const { result } = renderHook(() =>
+      useAssetAvailabilityData(items as Items)
+    );
+    expect(result.current.events).toHaveLength(1);
+    return result.current.events[0];
+  };
+
+  it("(i) keeps the full bar while any slice of the asset is still out", () => {
+    const event = eventFor([
+      {
+        id: "asset-1",
+        title: "Camera",
+        bookings: [
+          ongoing({ assetKitId: null, checkedOutAt: OUT, checkedInAt: BACK }),
+          ongoing({
+            assetKitId: "ak1",
+            kitName: "Kit",
+            checkedOutAt: OUT,
+            checkedInAt: null,
+          }),
+        ],
+      },
+    ]);
+
+    expect(event.end).toBe(iso(TO));
+    expect(event.title).toBe("Event");
+    expect(event.extendedProps).toMatchObject({
+      returned: false,
+      returnedAt: null,
+      status: "ONGOING",
+    });
+    expect(event.classNames).toContain("md:bg-purple-50");
+    expect(event.classNames).not.toContain("booking-returned");
+  });
+
+  it("(j) ends the bar at the check-in, styled as complete, once every slice is back", () => {
+    const event = eventFor([
+      {
+        id: "asset-1",
+        title: "Camera",
+        bookings: [ongoing({ checkedOutAt: OUT, checkedInAt: BACK })],
+      },
+    ]);
+
+    expect(event.end).toBe(iso(BACK));
+    expect(event.start).toBe(iso(FROM));
+    // The bar's "Returned <time>" prefix is rendered by the event card from
+    // `returnedAt`; the title stays the booking name.
+    expect(event.title).toBe("Event");
+    expect(event.classNames).toContain("booking-returned");
+    expect(event.classNames).toContain("md:bg-success-50");
+    expect(event.classNames).not.toContain("md:bg-purple-50");
+    // The popover keeps the booking's real period and status.
+    expect(event.extendedProps).toMatchObject({
+      status: "ONGOING",
+      end: TO,
+      returned: true,
+      returnedAt: BACK,
+    });
+  });
+
+  it("(k) keeps the custodian suffix on a returned bar's title", () => {
+    vi.mocked(userHasCustodyViewPermission).mockReturnValueOnce(true);
+    const event = eventFor([
+      {
+        id: "asset-1",
+        title: "Camera",
+        bookings: [
+          ongoing({
+            checkedOutAt: OUT,
+            checkedInAt: BACK,
+            custodianTeamMember: { id: "tm1", name: "Ada" },
+          }),
+        ],
+      },
+    ]);
+
+    expect(event.title).toBe("Event | Ada");
+  });
+
+  it("(l) never reads a RESERVED booking as returned", () => {
+    const event = eventFor([
+      {
+        id: "asset-1",
+        title: "Camera",
+        bookings: [
+          ongoing({ status: "RESERVED", checkedOutAt: OUT, checkedInAt: BACK }),
+        ],
+      },
+    ]);
+
+    expect(event.end).toBe(iso(TO));
+    expect(event.extendedProps).toMatchObject({ returned: false });
+    expect(event.classNames).toContain("md:bg-blue-50");
+  });
+
+  it("(m) keeps the full bar for a quantity-tracked slice that is only partly back", () => {
+    const event = eventFor([
+      {
+        id: "asset-qt",
+        title: "Cables",
+        type: "QUANTITY_TRACKED",
+        bookings: [
+          ongoing({ quantity: 5, checkedOutAt: OUT, checkedInAt: null }),
+        ],
+      },
+    ]);
+
+    expect(event.end).toBe(iso(TO));
+    expect(event.extendedProps).toMatchObject({ returned: false });
+  });
+
+  it("(n) treats a check-in older than the departure as not returned", () => {
+    // A row stamped by the check-in backfill can carry both markers with the
+    // check-in first; that is not a return.
+    const event = eventFor([
+      {
+        id: "asset-1",
+        title: "Camera",
+        bookings: [ongoing({ checkedOutAt: BACK, checkedInAt: OUT })],
+      },
+    ]);
+
+    expect(event.end).toBe(iso(TO));
+    expect(event.extendedProps).toMatchObject({ returned: false });
+  });
+
+  it("(o) keeps the bar end after its start when the check-in precedes the booking start", () => {
+    const event = eventFor([
+      {
+        id: "asset-1",
+        title: "Camera",
+        bookings: [
+          ongoing({
+            from: "2026-07-10T18:00:00.000Z",
+            checkedOutAt: "2026-07-10T08:00:00.000Z",
+            checkedInAt: "2026-07-10T09:00:00.000Z",
+          }),
+        ],
+      },
+    ]);
+
+    expect(new Date(event.end as string).getTime()).toBeGreaterThan(
+      new Date(event.start as string).getTime()
+    );
+    expect(event.end).toBe(iso("2026-07-10T19:00:00.000Z"));
+    expect(event.extendedProps).toMatchObject({
+      returned: true,
+      returnedAt: "2026-07-10T09:00:00.000Z",
+    });
+  });
+
+  it("(p) keeps the green fill for a same-day return", () => {
+    const event = eventFor([
+      {
+        id: "asset-1",
+        title: "Camera",
+        bookings: [
+          ongoing({
+            to: "2026-07-10T17:00:00.000Z",
+            checkedOutAt: OUT,
+            checkedInAt: BACK,
+          }),
+        ],
+      },
+    ]);
+
+    expect(event.classNames).toContain("md:bg-success-50");
+    expect(
+      event.classNames.some((c: string) => c.includes("!bg-transparent"))
+    ).toBe(false);
+  });
+
+  it("(q) reads the same markers from the simple-mode pivot shape, as Dates", () => {
+    const event = eventFor([
+      {
+        id: "asset-1",
+        title: "Camera",
+        bookingAssets: [
+          {
+            booking: ongoing(),
+            assetKitId: null,
+            quantity: 1,
+            checkedOutAt: new Date(OUT),
+            checkedInAt: new Date(BACK),
+          },
+        ],
+      },
+    ]);
+
+    expect(event.end).toBe(iso(BACK));
+    expect(event.extendedProps).toMatchObject({
+      returned: true,
+      returnedAt: BACK,
+    });
+  });
+
+  it("(r) folds the latest check-in across slices into returnedAt", () => {
+    const later = "2026-07-11T08:00:00.000Z";
+    const event = eventFor([
+      {
+        id: "asset-1",
+        title: "Camera",
+        bookings: [
+          ongoing({ assetKitId: null, checkedOutAt: OUT, checkedInAt: BACK }),
+          ongoing({
+            assetKitId: "ak1",
+            kitName: "Kit",
+            checkedOutAt: OUT,
+            checkedInAt: later,
+          }),
+        ],
+      },
+    ]);
+
+    expect(event.end).toBe(iso(later));
+    expect(event.extendedProps).toMatchObject({ returnedAt: later });
+  });
+});
+
+describe("returned-slice helpers", () => {
+  it("isSliceReturned needs a check-in at or after the departure", () => {
+    expect(isSliceReturned({ checkedOutAt: null, checkedInAt: null })).toBe(
+      false
+    );
+    expect(
+      isSliceReturned({
+        checkedOutAt: "2026-07-10T09:00:00.000Z",
+        checkedInAt: null,
+      })
+    ).toBe(false);
+    expect(
+      isSliceReturned({
+        checkedOutAt: null,
+        checkedInAt: "2026-07-10T09:00:00.000Z",
+      })
+    ).toBe(true);
+    expect(
+      isSliceReturned({
+        checkedOutAt: "2026-07-10T09:00:00.000Z",
+        checkedInAt: "2026-07-10T09:00:00.000Z",
+      })
+    ).toBe(true);
+    expect(
+      isSliceReturned({
+        checkedOutAt: "2026-07-10T10:00:00.000Z",
+        checkedInAt: "2026-07-10T09:00:00.000Z",
+      })
+    ).toBe(false);
+  });
+
+  it("resolveReturnedAt only answers for live bookings with every slice back", () => {
+    const back = {
+      checkedOutAt: "2026-07-10T09:00:00.000Z",
+      checkedInAt: "2026-07-10T12:00:00.000Z",
+    };
+    expect(resolveReturnedAt("ONGOING", [back])).toBe(
+      "2026-07-10T12:00:00.000Z"
+    );
+    expect(resolveReturnedAt("OVERDUE", [back])).toBe(
+      "2026-07-10T12:00:00.000Z"
+    );
+    expect(resolveReturnedAt("RESERVED", [back])).toBeNull();
+    expect(resolveReturnedAt("ONGOING", [])).toBeNull();
+    expect(
+      resolveReturnedAt("ONGOING", [
+        back,
+        { checkedOutAt: "2026-07-10T09:00:00.000Z", checkedInAt: null },
+      ])
+    ).toBeNull();
+  });
+
+  it("returnedBarEnd pushes an end at or before the start to one hour after it", () => {
+    expect(
+      returnedBarEnd("2026-07-10T12:00:00.000Z", "2026-07-10T09:00:00.000Z")
+    ).toBe("2026-07-10T12:00:00.000Z");
+    expect(
+      returnedBarEnd("2026-07-10T09:00:00.000Z", "2026-07-10T09:00:00.000Z")
+    ).toBe("2026-07-10T10:00:00.000Z");
+    expect(
+      returnedBarEnd(
+        "2026-07-10T08:00:00.000Z",
+        new Date("2026-07-10T09:00:00.000Z")
+      )
+    ).toBe("2026-07-10T10:00:00.000Z");
   });
 });

--- a/apps/webapp/app/components/assets/assets-index/use-asset-availability-data.ts
+++ b/apps/webapp/app/components/assets/assets-index/use-asset-availability-data.ts
@@ -44,6 +44,7 @@ type SimpleModeBookingAsset = {
 /** Slice markers the returned rule reads; both loader shapes carry them. */
 type SliceMarkers = Pick<BookingSlice, "checkedOutAt" | "checkedInAt">;
 
+/** Epoch milliseconds of an ISO string or Date, so both loader shapes compare alike. */
 const toMillis = (value: string | Date) => new Date(value).getTime();
 
 /** Milliseconds a returned bar spans when the check-in precedes the booking's
@@ -103,6 +104,12 @@ export function returnedBarEnd(
     : new Date(start + MIN_RETURNED_BAR_MS).toISOString();
 }
 
+/**
+ * Builds the resources (asset rows) and events (booking bars) the availability
+ * calendar renders from either loader shape.
+ * @param items - The assets index page items, simple or advanced mode
+ * @returns `resources` for the rows and `events` for the bars
+ */
 export function useAssetAvailabilityData(items: Items) {
   const { roles } = useUserRoleHelper();
   const organization = useCurrentOrganization();

--- a/apps/webapp/app/components/assets/assets-index/use-asset-availability-data.ts
+++ b/apps/webapp/app/components/assets/assets-index/use-asset-availability-data.ts
@@ -5,7 +5,10 @@ import { useCurrentOrganization } from "~/hooks/use-current-organization";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import type { AdvancedAssetBooking } from "~/modules/asset/types";
 import type { AssetIndexLoaderData } from "~/routes/_layout+/assets._index";
-import { getStatusClasses, isOneDayEvent } from "~/utils/calendar";
+import {
+  RETURNED_EVENT_CLASS,
+  availabilityEventClassNames,
+} from "~/utils/calendar";
 import { useHints } from "~/utils/client-hints";
 import { toIsoDateTimeToUserTimezone } from "~/utils/date-fns";
 import type { OrganizationPermissionSettings } from "~/utils/permissions/custody-and-bookings-permissions.validator.client";
@@ -22,15 +25,83 @@ type BookingSlice = {
   assetKitId: string | null;
   kitName: string | null;
   quantity: number;
+  checkedOutAt: string | Date | null;
+  checkedInAt: string | Date | null;
 };
 
-/** Simple-mode `asset.bookingAssets[]` element: pivot row + nested booking. */
+/** Simple-mode `asset.bookingAssets[]` element: pivot row + nested booking.
+ * The Prisma include returns every BookingAsset scalar, so the two slice
+ * markers arrive here as Dates without being named in the loader's select. */
 type SimpleModeBookingAsset = {
   booking: AdvancedAssetBooking;
   assetKitId?: string | null;
   kitName?: string | null;
   quantity?: number;
+  checkedOutAt?: string | Date | null;
+  checkedInAt?: string | Date | null;
 };
+
+/** Slice markers the returned rule reads; both loader shapes carry them. */
+type SliceMarkers = Pick<BookingSlice, "checkedOutAt" | "checkedInAt">;
+
+const toMillis = (value: string | Date) => new Date(value).getTime();
+
+/** Milliseconds a returned bar spans when the check-in precedes the booking's
+ * start (early check-out without a date adjustment, then a return): the
+ * calendar needs an end after the start, and one hour keeps the bar visible. */
+const MIN_RETURNED_BAR_MS = 60 * 60 * 1000;
+
+/**
+ * Whether ONE slice has come back from its booking. A departure clears
+ * `checkedInAt`, but rows stamped by the check-in backfill can carry a
+ * `checkedInAt` older than their `checkedOutAt`; only a check-in at or after
+ * the departure means the slice is back — the same test the booking's own
+ * completion gate applies.
+ */
+export function isSliceReturned(slice: SliceMarkers): boolean {
+  if (!slice.checkedInAt) return false;
+  if (!slice.checkedOutAt) return true;
+  return toMillis(slice.checkedInAt) >= toMillis(slice.checkedOutAt);
+}
+
+/**
+ * The instant an asset's bar should end for one booking: the latest check-in
+ * across its folded slices, or null when the asset is still booked or out.
+ *
+ * Only a live booking can have a returned asset. A RESERVED booking has not
+ * started, so its slices are drawn for the whole planned period whatever
+ * markers they carry. A QUANTITY_TRACKED slice gets `checkedInAt` only once
+ * every booked unit is back; a partly returned pool keeps its full bar (its
+ * flow back is tracked by ConsumptionLog, not drawn here).
+ */
+export function resolveReturnedAt(
+  status: AdvancedAssetBooking["status"],
+  slices: SliceMarkers[]
+): string | null {
+  if (status !== "ONGOING" && status !== "OVERDUE") return null;
+  if (slices.length === 0 || !slices.every(isSliceReturned)) return null;
+  const latest = Math.max(
+    ...slices.map((s) => toMillis(s.checkedInAt as string | Date))
+  );
+  return new Date(latest).toISOString();
+}
+
+/**
+ * The bar end for a returned asset. The calendar drops an end that is not
+ * after the start and draws a default-length bar instead, so a check-in
+ * recorded before the booking's (unadjusted) start is pushed to one hour
+ * after it.
+ */
+export function returnedBarEnd(
+  returnedAt: string,
+  from: string | Date
+): string {
+  const start = toMillis(from);
+  const end = toMillis(returnedAt);
+  return end > start
+    ? returnedAt
+    : new Date(start + MIN_RETURNED_BAR_MS).toISOString();
+}
 
 export function useAssetAvailabilityData(items: Items) {
   const { roles } = useUserRoleHelper();
@@ -101,6 +172,8 @@ export function useAssetAvailabilityData(items: Items) {
                 assetKitId: ba.assetKitId ?? null,
                 kitName: ba.kitName ?? null,
                 quantity: ba.quantity ?? 1,
+                checkedOutAt: ba.checkedOutAt ?? null,
+                checkedInAt: ba.checkedInAt ?? null,
               })
             )
           : "bookings" in asset && asset.bookings
@@ -109,6 +182,8 @@ export function useAssetAvailabilityData(items: Items) {
               assetKitId: b.assetKitId ?? null,
               kitName: b.kitName ?? null,
               quantity: b.quantity ?? 1,
+              checkedOutAt: b.checkedOutAt ?? null,
+              checkedInAt: b.checkedInAt ?? null,
             }))
           : [];
 
@@ -136,6 +211,14 @@ export function useAssetAvailabilityData(items: Items) {
           ? resolveUserDisplayName(booking.custodianUser)
           : booking.custodianTeamMember?.name;
 
+        // Every folded slice of this asset is back from a live booking: the
+        // bar stops at the check-in and is drawn as settled, while the
+        // booking keeps its live status (ONGOING or OVERDUE) until it is
+        // completed. Slices that never went out on this booking keep the
+        // planned bar.
+        const returnedAt = resolveReturnedAt(booking.status, group);
+        const returned = returnedAt !== null;
+
         let title = booking.name;
         if (canSeeAllCustody) {
           title += ` | ${custodianName}`;
@@ -153,16 +236,24 @@ export function useAssetAvailabilityData(items: Items) {
           0
         );
 
+        const barEnd = returnedAt
+          ? returnedBarEnd(returnedAt, booking.from)
+          : booking.to;
+
         return {
           title,
           resourceId: asset.id,
           start: toIsoDateTimeToUserTimezone(booking.from, timeZone),
-          end: toIsoDateTimeToUserTimezone(booking.to, timeZone),
+          end: toIsoDateTimeToUserTimezone(barEnd, timeZone),
           classNames: [
             `bookingId-${booking.id}`,
-            ...getStatusClasses(
-              booking.status,
-              isOneDayEvent(new Date(booking.from), new Date(booking.to)),
+            ...(returned ? [RETURNED_EVENT_CLASS] : []),
+            // Same rule the calendar's own class callback applies, so the bar
+            // is drawn the same way from both sides.
+            ...availabilityEventClassNames(
+              { status: booking.status, returned },
+              new Date(booking.from),
+              new Date(booking.to),
               "px-1"
             ),
           ],
@@ -171,6 +262,8 @@ export function useAssetAvailabilityData(items: Items) {
             id: booking.id,
             name: booking.name,
             status: booking.status,
+            returned,
+            returnedAt,
             title: booking.name,
             description: booking.description,
             start: booking.from,

--- a/apps/webapp/app/components/availability-calendar/availability-calendar.tsx
+++ b/apps/webapp/app/components/availability-calendar/availability-calendar.tsx
@@ -20,13 +20,13 @@ import { ViewButtonGroup } from "~/components/calendar/view-button-group";
 import FallbackLoading from "~/components/dashboard/fallback-loading";
 import { useDateFormatter } from "~/hooks/use-date-formatter";
 import type { AssetIndexLoaderData } from "~/routes/_layout+/assets._index";
+import type { CalendarExtendedProps } from "~/routes/_layout+/calendar";
 import {
+  availabilityEventClassNames,
   getCalendarTitleAndSubtitle,
-  getStatusClasses,
   handleEventClick,
   handleEventMouseEnter,
   handleEventMouseLeave,
-  isOneDayEvent,
   scrollToNow,
 } from "~/utils/calendar";
 import { getWeekStartingAndEndingDates } from "~/utils/date-fns";
@@ -226,19 +226,14 @@ export default function AvailabilityCalendar({
               resourceAreaWidth="35%"
               resourceLabelContent={resourceLabelContent}
               eventContent={renderEventCard}
-              eventClassNames={(eventInfo) => {
-                const viewType = eventInfo.view.type;
-                const isOneDay = isOneDayEvent(
+              eventClassNames={(eventInfo) =>
+                availabilityEventClassNames(
+                  eventInfo.event.extendedProps as CalendarExtendedProps,
                   eventInfo.event.start,
-                  eventInfo.event.end
-                );
-
-                return getStatusClasses(
-                  eventInfo.event.extendedProps.status,
-                  isOneDay,
-                  viewType
-                );
-              }}
+                  eventInfo.event.end,
+                  eventInfo.view.type
+                )
+              }
               nowIndicatorDidMount={handleNowIndicatorDidMount}
               viewDidMount={handleViewDidMount}
               datesSet={handleDatesSet}

--- a/apps/webapp/app/components/calendar/event-card.test.tsx
+++ b/apps/webapp/app/components/calendar/event-card.test.tsx
@@ -17,13 +17,14 @@
  * @see {@link file://./event-card.tsx}
  */
 import type { EventContentArg } from "@fullcalendar/core";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import type {
   AvailabilitySlice,
   CalendarExtendedProps,
 } from "~/routes/_layout+/calendar";
+import { bookingStatusColorMap } from "~/utils/bookings";
 import renderEventCard, { EventCardContent } from "./event-card";
 
 // why: DateS reads client hints from Remix context unavailable in the test;
@@ -41,7 +42,9 @@ vi.mock("~/components/user/team-member-badge", () => ({
 // why: BookingStatusBadge reads user data + roles from Remix context; the
 // status chip is orthogonal to the slice breakdown/glyph gating.
 vi.mock("~/components/booking/booking-status-badge", () => ({
-  BookingStatusBadge: () => <span>status</span>,
+  BookingStatusBadge: ({ status }: { status: string }) => (
+    <span data-testid="status-badge">{status}</span>
+  ),
 }));
 
 /** Builds a CalendarExtendedProps booking with sane defaults. Omit
@@ -171,6 +174,81 @@ describe("EventCardContent — per-slice breakdown gating", () => {
     // ...but the redundant per-slice Qty and the total are suppressed.
     expect(screen.queryByText(/^Qty /)).toBeNull();
     expect(screen.queryByText(/Total reserved/)).toBeNull();
+  });
+});
+
+describe("EventCardContent — returned asset", () => {
+  it("adds a returned line under the period and keeps the real status badge", () => {
+    render(
+      <EventCardContent
+        booking={makeBooking({
+          status: "ONGOING",
+          returned: true,
+          returnedAt: "2026-07-10T15:30:00.000Z",
+        })}
+      />
+    );
+
+    const line = screen.getByTestId("event-card-returned");
+    expect(line).toHaveTextContent("Returned");
+    // The return instant is printed on the line (DateS is stubbed to "date").
+    expect(within(line).getByText("date")).toBeInTheDocument();
+    // The badge is the booking's own status, not the bar's display status.
+    expect(screen.getByTestId("status-badge")).toHaveTextContent("ONGOING");
+  });
+
+  it("colours the bar text as complete for a returned asset", () => {
+    render(
+      <RenderedEventCard
+        {...makeEventArg(
+          makeBooking({
+            status: "ONGOING",
+            returned: true,
+            returnedAt: "2026-07-10T15:30:00.000Z",
+          })
+        )}
+      />
+    );
+
+    // The colour sits on the trigger wrapper around the inner card content.
+    const trigger = screen
+      .getByText(/Test Booking/)
+      .closest(".inner-event-card-wrapper")?.parentElement;
+    expect(trigger?.style.color).toBe(bookingStatusColorMap.COMPLETE.text);
+  });
+
+  it("prefixes a returned bar with the return time instead of the booking start", () => {
+    render(
+      <RenderedEventCard
+        {...makeEventArg(
+          makeBooking({
+            status: "ONGOING",
+            returned: true,
+            returnedAt: "2026-07-10T15:30:00.000Z",
+          })
+        )}
+      />
+    );
+
+    const prefix = screen.getByTestId("event-card-returned-prefix");
+    expect(prefix).toHaveTextContent("Returned");
+    expect(within(prefix).getByText("date")).toBeInTheDocument();
+  });
+
+  it("prefixes a live bar with the booking start", () => {
+    render(
+      <RenderedEventCard
+        {...makeEventArg(makeBooking({ status: "ONGOING" }))}
+      />
+    );
+
+    expect(screen.queryByTestId("event-card-returned-prefix")).toBeNull();
+  });
+
+  it("shows no returned line for the booking-calendar shape", () => {
+    render(<EventCardContent booking={makeBooking()} />);
+
+    expect(screen.queryByTestId("event-card-returned")).toBeNull();
   });
 });
 

--- a/apps/webapp/app/components/calendar/event-card.tsx
+++ b/apps/webapp/app/components/calendar/event-card.tsx
@@ -1,10 +1,10 @@
 import type { EventContentArg } from "@fullcalendar/core";
 import { ExternalLinkIcon } from "@radix-ui/react-icons";
-import { ArrowRightIcon, Boxes } from "lucide-react";
+import { ArrowRightIcon, Boxes, CheckIcon } from "lucide-react";
 
 import { type CalendarExtendedProps } from "~/routes/_layout+/calendar";
 import { bookingStatusColorMap } from "~/utils/bookings";
-import { isOneDayEvent } from "~/utils/calendar";
+import { calendarDisplayStatus, isOneDayEvent } from "~/utils/calendar";
 import { tw } from "~/utils/tw";
 import { BookingStatusBadge } from "../booking/booking-status-badge";
 import { DateS } from "../shared/date";
@@ -196,7 +196,9 @@ export default function renderEventCard({ event }: EventCardProps) {
     (element as any)._cleanup = cleanup;
   };
 
-  const colors = bookingStatusColorMap[booking.status];
+  // The bar's text colour follows what the bar is drawn as, so a returned
+  // bar reads green throughout; the popover badge below keeps the real status.
+  const colors = bookingStatusColorMap[calendarDisplayStatus(booking)];
   return (
     <HoverCard openDelay={0} closeDelay={0}>
       <HoverCardTrigger asChild>
@@ -216,8 +218,20 @@ export default function renderEventCard({ event }: EventCardProps) {
                 <div className="fc-daygrid-event-dot inline-block" />
               </When>
             )}
-            <DateS date={booking.start} options={{ timeStyle: "short" }} /> |{" "}
-            {event.title}
+            {/* The bar must read without hovering: a returned asset shows
+                when it came back instead of when the booking started. */}
+            {booking.returnedAt ? (
+              <span data-testid="event-card-returned-prefix">
+                Returned{" "}
+                <DateS
+                  date={booking.returnedAt}
+                  options={{ timeStyle: "short" }}
+                />
+              </span>
+            ) : (
+              <DateS date={booking.start} options={{ timeStyle: "short" }} />
+            )}{" "}
+            | {event.title}
             {showKitGlyph ? (
               <span
                 className="inline-flex items-center gap-0.5"
@@ -296,6 +310,18 @@ export function EventCardContent({
         <ArrowRightIcon className="size-3 text-gray-600" />
         <DateS date={booking.end} options={DATE_FORMAT_OPTIONS} />
       </div>
+
+      {/* The period above is the booking's; this asset left it earlier. */}
+      {booking.returnedAt ? (
+        <div
+          className="mb-3 flex w-full items-center gap-x-2 text-sm text-success-700"
+          data-testid="event-card-returned"
+        >
+          <CheckIcon className="size-3" aria-hidden="true" />
+          <span>Returned</span>
+          <DateS date={booking.returnedAt} options={DATE_FORMAT_OPTIONS} />
+        </div>
+      ) : null}
 
       <div className="flex items-center gap-5">
         <div>

--- a/apps/webapp/app/modules/asset/query.server.test.ts
+++ b/apps/webapp/app/modules/asset/query.server.test.ts
@@ -1093,6 +1093,10 @@ describe("assetQueryFragment", () => {
       // Per-slice pivot metadata the fold reads (booked units, kit membership).
       expect(sql).toContain('atb."assetKitId"');
       expect(sql).toContain('atb."quantity"');
+      // Slice markers the returned rule reads: the bar of an asset that is
+      // back from a live booking ends at its check-in, not the booking's end.
+      expect(sql).toContain(`'checkedOutAt', atb."checkedOutAt"`);
+      expect(sql).toContain(`'checkedInAt', atb."checkedInAt"`);
       // Kit name resolved through org-scoped AssetKit -> Kit joins, using
       // aliases (bk_ak/bk_kit) distinct from the outer query's own-kit ak/k.
       expect(sql).toContain("'kitName', bk_kit.name");
@@ -1111,6 +1115,7 @@ describe("assetQueryFragment", () => {
       // Default (table views) must not pay for the availability-only subquery.
       expect(sql).not.toContain("AS bookings");
       expect(sql).not.toContain('atb."assetKitId"');
+      expect(sql).not.toContain('atb."checkedInAt"');
       expect(sql).not.toContain("'kitName', bk_kit.name");
     });
   });

--- a/apps/webapp/app/modules/asset/query.server.ts
+++ b/apps/webapp/app/modules/asset/query.server.ts
@@ -2010,7 +2010,13 @@ export const assetQueryFragment = (options: AssetQueryOptions = {}) => {
             END,
             'assetKitId', atb."assetKitId",
             'quantity', atb."quantity",
-            'kitName', bk_kit.name
+            'kitName', bk_kit.name,
+            -- Slice markers the availability bar reads to end a returned
+            -- asset's bar at its check-in instead of the booking's end.
+            -- Unwrapped like from/to above: timestamptz serialises with its
+            -- offset and the hook parses it with new Date().
+            'checkedOutAt', atb."checkedOutAt",
+            'checkedInAt', atb."checkedInAt"
           )
         ),
         '[]'::jsonb

--- a/apps/webapp/app/modules/asset/types.ts
+++ b/apps/webapp/app/modules/asset/types.ts
@@ -181,6 +181,15 @@ export type AdvancedAssetBooking = Pick<
   /** Kit name for THIS slice (null when standalone), resolved via
    * AssetKit → Kit.name. Availability view only. */
   kitName?: string | null;
+  /** BookingAsset.checkedOutAt of THIS slice: null until the slice goes out.
+   * Advanced mode delivers an ISO string (jsonb), simple mode a Date.
+   * Availability view only. */
+  checkedOutAt?: string | Date | null;
+  /** BookingAsset.checkedInAt of THIS slice: set once the slice is fully
+   * reconciled, cleared again by a second departure. The calendar reads it
+   * together with `checkedOutAt` to decide whether the bar reads as returned.
+   * Availability view only. */
+  checkedInAt?: string | Date | null;
 };
 
 /** Type for advanced index query. We cannot infer it because we do a raw query so we need to create it ourselves. */

--- a/apps/webapp/app/routes/_layout+/calendar.tsx
+++ b/apps/webapp/app/routes/_layout+/calendar.tsx
@@ -105,6 +105,14 @@ export type CalendarExtendedProps = {
    * physical units (always qty 1), so the calendar hides the per-slice `Qty`
    * and the booked-units total for them — the number is redundant noise. */
   quantityTracked?: boolean;
+  /** Availability view only: true when every folded slice of this asset has
+   * been checked in from the booking. The bar then ends at `returnedAt` and
+   * is styled as complete, while `status` keeps the booking's real status
+   * for the popover badge. Absent on the booking calendar. */
+  returned?: boolean;
+  /** Availability view only: ISO instant of the latest check-in among the
+   * folded slices; null unless `returned`. */
+  returnedAt?: string | null;
 };
 
 // Loader Function to Return Bookings Data

--- a/apps/webapp/app/routes/_layout+/kits._index.tsx
+++ b/apps/webapp/app/routes/_layout+/kits._index.tsx
@@ -151,6 +151,9 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
                   // PrismaClientValidationError on every kit search with
                   // ?view=availability (Sentry SHELF-WEBAPP-1P1).
                   ...(view === "availability" && {
+                    // why: out of this rule — a kit bar means "every member
+                    // slice returned", which needs a per-kit fold this select
+                    // does not carry, so kit bars keep the booking's period.
                     bookingAssets: {
                       where: {
                         booking: {

--- a/apps/webapp/app/utils/calendar-returned-hover.test.ts
+++ b/apps/webapp/app/utils/calendar-returned-hover.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Hover styling for returned bars on the availability calendar.
+ *
+ * A booking's hover repaints every bar that carries its `bookingId-<id>`
+ * class, across all asset rows. A bar already drawn as returned (green) must
+ * keep the COMPLETE hover, whichever row the pointer is on, and the hovered
+ * bar's own hover follows what it is drawn as, not the booking's raw status.
+ *
+ * @see {@link file://./calendar.ts}
+ */
+// @vitest-environment happy-dom
+import type { EventHoveringArg } from "@fullcalendar/core";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  RETURNED_EVENT_CLASS,
+  availabilityEventClassNames,
+  calendarDisplayStatus,
+  handleEventMouseEnter,
+  handleEventMouseLeave,
+  statusClassesOnHover,
+} from "./calendar";
+
+const VIEW = "resourceTimelineMonth";
+
+/** Two bars of one ONGOING booking on two asset rows: one still out, one
+ * returned. Returns the elements plus a hover arg built for `hovered`. */
+function twoBars(hovered: "live" | "returned") {
+  const live = document.createElement("div");
+  live.className = "bookingId-b1";
+  const returned = document.createElement("div");
+  returned.className = `bookingId-b1 ${RETURNED_EVENT_CLASS}`;
+  document.body.append(live, returned);
+
+  const el = hovered === "live" ? live : returned;
+  const info = {
+    el,
+    view: { type: VIEW },
+    event: {
+      _def: {
+        extendedProps: {
+          id: "b1",
+          status: "ONGOING",
+          returned: hovered === "returned",
+        },
+      },
+    },
+  } as unknown as EventHoveringArg;
+
+  return { live, returned, info };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("calendarDisplayStatus", () => {
+  it("borrows COMPLETE for a returned bar and keeps the real status otherwise", () => {
+    expect(calendarDisplayStatus({ status: "ONGOING", returned: true })).toBe(
+      "COMPLETE"
+    );
+    expect(calendarDisplayStatus({ status: "ONGOING", returned: false })).toBe(
+      "ONGOING"
+    );
+    expect(calendarDisplayStatus({ status: "RESERVED" })).toBe("RESERVED");
+  });
+});
+
+describe("availabilityEventClassNames", () => {
+  const sameDayStart = new Date("2026-07-10T09:00:00.000Z");
+  const sameDayEnd = new Date("2026-07-10T15:30:00.000Z");
+
+  it("draws a returned bar with the COMPLETE palette and keeps its fill on a same-day return", () => {
+    const classes = availabilityEventClassNames(
+      { status: "ONGOING", returned: true },
+      sameDayStart,
+      sameDayEnd,
+      "resourceTimelineMonth"
+    );
+
+    expect(classes).toContain("md:bg-success-50");
+    expect(classes).not.toContain("md:bg-purple-50");
+    expect(classes.some((c) => c.includes("!bg-transparent"))).toBe(false);
+  });
+
+  it("leaves a live same-day bar on the one-day treatment", () => {
+    const classes = availabilityEventClassNames(
+      { status: "ONGOING" },
+      sameDayStart,
+      sameDayEnd,
+      "resourceTimelineMonth"
+    );
+
+    expect(classes).toContain("md:bg-purple-50");
+    expect(classes.some((c) => c.includes("!bg-transparent"))).toBe(true);
+  });
+});
+
+describe("hover on a booking with a returned bar", () => {
+  it("hovering the live bar does not paint the returned bar as live", () => {
+    const { live, returned, info } = twoBars("live");
+
+    handleEventMouseEnter(VIEW)(info);
+
+    expect(live.classList.contains(statusClassesOnHover.ONGOING)).toBe(true);
+    expect(returned.classList.contains(statusClassesOnHover.ONGOING)).toBe(
+      false
+    );
+    expect(returned.classList.contains(statusClassesOnHover.COMPLETE)).toBe(
+      true
+    );
+
+    handleEventMouseLeave(VIEW)(info);
+
+    expect(live.classList.contains(statusClassesOnHover.ONGOING)).toBe(false);
+    expect(returned.classList.contains(statusClassesOnHover.COMPLETE)).toBe(
+      false
+    );
+  });
+
+  it("hovering the returned bar keeps the live sibling in the booking's own hover colour", () => {
+    const { live, returned, info } = twoBars("returned");
+
+    handleEventMouseEnter(VIEW)(info);
+
+    expect(returned.classList.contains(statusClassesOnHover.COMPLETE)).toBe(
+      true
+    );
+    // Every bar of one booking highlights together, each in the colour it is
+    // drawn with: the sibling is still out, so it must not turn green.
+    expect(live.classList.contains(statusClassesOnHover.ONGOING)).toBe(true);
+    expect(live.classList.contains(statusClassesOnHover.COMPLETE)).toBe(false);
+
+    handleEventMouseLeave(VIEW)(info);
+
+    expect(returned.classList.contains(statusClassesOnHover.COMPLETE)).toBe(
+      false
+    );
+    expect(live.classList.contains(statusClassesOnHover.ONGOING)).toBe(false);
+  });
+
+  it("hovering a returned bar on an OVERDUE booking keeps the sibling red", () => {
+    const { live, returned, info } = twoBars("returned");
+    (
+      info.event as unknown as { _def: { extendedProps: { status: string } } }
+    )._def.extendedProps.status = "OVERDUE";
+
+    handleEventMouseEnter(VIEW)(info);
+
+    expect(returned.classList.contains(statusClassesOnHover.COMPLETE)).toBe(
+      true
+    );
+    expect(live.classList.contains(statusClassesOnHover.OVERDUE)).toBe(true);
+  });
+});

--- a/apps/webapp/app/utils/calendar.ts
+++ b/apps/webapp/app/utils/calendar.ts
@@ -42,6 +42,13 @@ export function availabilityEventClassNames(
   return getStatusClasses(calendarDisplayStatus(props), oneDay, viewType);
 }
 
+/**
+ * Tailwind classes for a calendar bar of the given booking status.
+ * @param status - The status the bar is drawn as (see `calendarDisplayStatus`)
+ * @param oneDayEvent - True renders the dot-style, transparent one-day variant
+ * @param viewType - FullCalendar view type; time-grid views add the hover class
+ * @returns The class list for the bar element
+ */
 export function getStatusClasses(
   status: BookingStatus,
   oneDayEvent: boolean = false,
@@ -94,10 +101,9 @@ export function getStatusClasses(
         "md:focus:!bg-purple-100",
       ];
       break;
-    // Red, not amber. `bookingStatusColorMap` maps OVERDUE to red and every
-    // other place a booking status is shown reads from it - the badge on the
-    // bookings index, the booking detail, the asset page, the companion app.
-    // The calendar was the only surface calling an overdue booking a warning.
+    // Red, never amber: every surface that shows a booking status reads
+    // `bookingStatusColorMap`, which maps OVERDUE to the error palette, and
+    // the calendar must agree with them.
     case "OVERDUE":
       statusClasses = [
         "md:!text-error-700",
@@ -140,6 +146,10 @@ export const statusClassesOnHover: Record<BookingStatus, string> = {
   COMPLETE: "md:!bg-success-100",
 };
 
+/**
+ * Whether the two instants fall on the same calendar day (local time).
+ * @returns False when either bound is missing
+ */
 export function isOneDayEvent(
   from: Date | string | null,
   to: Date | string | null
@@ -161,7 +171,9 @@ export function isOneDayEvent(
 
 /**
  * Handles the mouse enter event for calendar events.
- * It applies a hover effect based on the event's status and the allowed view type.
+ * Highlights every bar of the hovered booking, each in the hover colour of
+ * its own rendered state: the booking's status, or COMPLETE for a bar that
+ * carries `RETURNED_EVENT_CLASS`.
  * @param allowedViewType - The view type(s) where the hover effect should be applied.
  */
 export const handleEventMouseEnter =
@@ -244,7 +256,9 @@ function hoverClassForElement(
 
 /**
  * Handles the mouse leave event for calendar events.
- * It removes the hover effect based on the event's status and the allowed view type.
+ * Removes from every bar of the booking the hover class that
+ * `handleEventMouseEnter` added for that bar's rendered state, including
+ * the COMPLETE hover on bars carrying `RETURNED_EVENT_CLASS`.
  * @param allowedViewType - The view type(s) where the hover effect should be removed.
  */
 export const handleEventMouseLeave =

--- a/apps/webapp/app/utils/calendar.ts
+++ b/apps/webapp/app/utils/calendar.ts
@@ -7,6 +7,41 @@ import type { BookingStatus } from "@prisma/client";
 import { formatDate, type ResolvedFormatPrefs } from "~/utils/date-format";
 import { getWeekStartingAndEndingDates } from "./date-fns";
 
+/**
+ * Class the availability hook puts on a bar whose asset has been checked in
+ * from the booking. Read back by the hover handlers below, which repaint every
+ * bar of a booking at once and must not turn a returned bar into a live one.
+ */
+export const RETURNED_EVENT_CLASS = "booking-returned";
+
+/**
+ * The status a calendar bar is DRAWN with. A returned bar borrows the
+ * COMPLETE palette so it reads as settled, while `status` itself keeps the
+ * booking's real value for the popover badge and any other status logic.
+ */
+export function calendarDisplayStatus(props: {
+  status: BookingStatus;
+  returned?: boolean;
+}): BookingStatus {
+  return props.returned ? "COMPLETE" : props.status;
+}
+
+/**
+ * Classes for one bar on the availability calendar. A returned bar is drawn
+ * with the COMPLETE palette and is never treated as a one-day event, because
+ * that treatment strips the fill and the bar's point is its fill up to the
+ * check-in time. Every other bar keeps the status and one-day rules as is.
+ */
+export function availabilityEventClassNames(
+  props: { status: BookingStatus; returned?: boolean },
+  start: Date | string | null,
+  end: Date | string | null,
+  viewType?: string
+): string[] {
+  const oneDay = props.returned ? false : isOneDayEvent(start, end);
+  return getStatusClasses(calendarDisplayStatus(props), oneDay, viewType);
+}
+
 export function getStatusClasses(
   status: BookingStatus,
   oneDayEvent: boolean = false,
@@ -182,15 +217,30 @@ export const handleEventMouseEnter =
       if (viewType !== allowedViewType) return;
     }
 
-    const statusClass: BookingStatus = info.event._def.extendedProps.status;
+    const statusClass = info.event._def.extendedProps.status as BookingStatus;
     const className = "bookingId-" + info.event._def.extendedProps.id;
     const elements = document.getElementsByClassName(className);
 
     for (let i = 0; i < elements.length; i++) {
       const element = elements[i] as HTMLElement;
-      element.classList.add(statusClassesOnHover[statusClass]);
+      element.classList.add(hoverClassForElement(element, statusClass));
     }
   };
+
+/**
+ * One booking spans several asset rows and the hover paints all of them, so
+ * each row picks its own hover colour from what it is drawn as: a bar marked
+ * returned takes the COMPLETE hover, every other bar takes the hover of the
+ * booking's real status. Which bar the pointer is on does not matter.
+ */
+function hoverClassForElement(
+  element: HTMLElement,
+  bookingStatus: BookingStatus
+): string {
+  return element.classList.contains(RETURNED_EVENT_CLASS)
+    ? statusClassesOnHover.COMPLETE
+    : statusClassesOnHover[bookingStatus];
+}
 
 /**
  * Handles the mouse leave event for calendar events.
@@ -199,7 +249,7 @@ export const handleEventMouseEnter =
  */
 export const handleEventMouseLeave =
   (allowedViewType: string | string[]) => (info: EventHoveringArg) => {
-    // Show the new tab icon on hover
+    // Hide the new-tab icon again when the pointer leaves
     const newTabIcon = info.el?.querySelector(
       ".external-link-icon"
     ) as HTMLElement | null;
@@ -237,12 +287,12 @@ export const handleEventMouseLeave =
       if (viewType !== allowedViewType) return;
     }
 
-    const statusClass: BookingStatus = info.event._def.extendedProps.status;
+    const statusClass = info.event._def.extendedProps.status as BookingStatus;
     const className = "bookingId-" + info.event._def.extendedProps.id;
     const elements = document.getElementsByClassName(className);
     for (let i = 0; i < elements.length; i++) {
       const element = elements[i] as HTMLElement;
-      element.classList.remove(statusClassesOnHover[statusClass]);
+      element.classList.remove(hoverClassForElement(element, statusClass));
     }
   };
 


### PR DESCRIPTION
## What

On `/assets?view=availability`, an asset that was checked in from a live booking (partial check-in) kept that booking's full bar until the booking ended, so the calendar showed it as taken. The booking rules already treat it as free: the picker lists it and a new booking can reserve it. The asset overview also hides the booking. The calendar was the only surface still drawing the old state.

Now the bar of a returned asset ends at its check-in, is drawn with the complete (green) palette, and reads `Returned <time> | booking | custodian` on the bar itself. The popover keeps the booking's real status badge and period and adds a `Returned <time>` line.

## How

- **Signal is the slice.** `BookingAsset.checkedOutAt` / `checkedInAt` per `.claude/rules/booking-checkout-is-recorded-per-slice.md`. Simple mode already returns them (the pivot is an `include`); the advanced-mode subquery adds the two jsonb keys. `AdvancedAssetBooking` and `CalendarExtendedProps` are widened (`returned`, `returnedAt`).
- **Rule** (`resolveReturnedAt` in `use-asset-availability-data.ts`): only ONGOING/OVERDUE bookings; every folded slice of the asset must be back; a check-in is a return only when it is at or after the departure, the same test `isBookingFullyCheckedIn` applies, which keeps rows stamped by the check-in backfill from reading as returned.
- **Bar end** (`returnedBarEnd`): the latest check-in, or one hour after the start when the check-in precedes an unadjusted early-checkout start. FullCalendar drops an end that is not after the start.
- **One source for styling**: `availabilityEventClassNames` in `utils/calendar.ts` is used by the hook and the calendar's `eventClassNames` callback. A returned bar is never treated as a one-day event, so a same-day return keeps its fill. `calendarDisplayStatus` gives the event card its text colour.
- **Hover**: the sweep over a booking's bars keys each bar to its own state (`booking-returned` class), so hovering a returned bar does not paint a still-out sibling green and vice versa.

## Out of scope, stated on purpose

- Kits availability calendar: kit rows keep the full bar; a kit bar needs a per-kit "every member slice returned" fold that its select does not carry (`// why:` at the include).
- Slices on a live booking that never went out (added after departure, or removed and re-added) still draw the planned bar.
- The bookings calendar (`/calendar`) draws one bar per booking and is unchanged.

## Tests

- `use-asset-availability-data.test.ts`: 13 new cases (mixed slices, all returned, RESERVED ignored, QT partial return, stale marker, check-in before start, same-day fill, both loader shapes, latest check-in wins, helper units).
- `calendar-returned-hover.test.ts` (new): `availabilityEventClassNames` and the hover sweep on ONGOING and OVERDUE bookings.
- `event-card.test.tsx`: text colour, `Returned` prefix on returned bars only, popover line with the time, real status badge kept.
- `query.server.test.ts`: the two jsonb keys are projected with `withBookings` and absent without.

`pnpm -F webapp typecheck`, lint on the touched files, and the four touched test files (158 tests) pass.

## Verified in a browser

Local build against the QA database: booking over three days with two individual assets, both checked out, one partially checked in. Month view in both index modes: the returned asset shows the short green `Returned 10:35` bar, the other keeps the full purple bar; the popover shows the ONGOING badge, the booking period and the return time; hovering the purple bar leaves the green one green. A second departure of the returned asset turns its bar purple again. Before/after renders were shared internally.

## Deploy

No migration, no new setting, no companion change. Safe to deploy in any order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Availability calendars show returned assets with completed styling and accurate return times.
  * Event cards display a “Returned” indicator and return time when applicable.
  * Calendar hover behavior reflects returned and active booking states.
  * Availability timelines include checkout and check-in details.

* **Bug Fixes**
  * Returned asset bars maintain a visible duration and accurate end time.
  * Booking status colors remain accurate when returned and active bars appear together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->