### PR TITLE
feat(assets): link the tracking-method row to the choose-a-method guide

### DIFF
--- a/apps/webapp/app/components/assets/form.tsx
+++ b/apps/webapp/app/components/assets/form.tsx
@@ -375,6 +375,13 @@ export const AssetForm = ({
 
   /** Whether we are in edit mode (asset already exists). */
   const isEditMode = Boolean(id);
+
+  /** Sub-heading for the tracking-method row; repeated under the cards on
+   * narrow viewports because FormRow hides its label column there. */
+  const trackingMethodHint = isEditMode
+    ? "Tracking method cannot be changed after creation."
+    : "Choose how this asset is tracked. This cannot be changed later.";
+
   /** Track the selected asset type for conditional field rendering. */
   const [selectedAssetType, setSelectedAssetType] = useState<AssetType>(
     bulkMode ? AssetType.INDIVIDUAL : assetType ?? AssetType.INDIVIDUAL
@@ -816,32 +823,10 @@ export const AssetForm = ({
             rowLabel={"Tracking method"}
             className="border-b-0 pb-[10px]"
             subHeading={
-              isEditMode ? (
-                <p>
-                  Tracking method cannot be changed after creation.{" "}
-                  <Button
-                    to={`${TRACKING_METHOD_KB_URL}#what-you-can-and-cannot-change-later`}
-                    variant="link-gray"
-                    className="text-gray-600 underline"
-                    target="_blank"
-                  >
-                    Picked the wrong one?
-                  </Button>
-                </p>
-              ) : (
-                <p>
-                  Choose how this asset is tracked. This cannot be changed
-                  later.{" "}
-                  <Button
-                    to={TRACKING_METHOD_KB_URL}
-                    variant="link-gray"
-                    className="text-gray-600 underline"
-                    target="_blank"
-                  >
-                    Which should I pick?
-                  </Button>
-                </p>
-              )
+              <p>
+                {trackingMethodHint}{" "}
+                <TrackingMethodGuideLink isEditMode={isEditMode} />
+              </p>
             }
             required={true}
           >
@@ -852,6 +837,13 @@ export const AssetForm = ({
               disabled={disabled || isEditMode}
               isEditMode={isEditMode}
             />
+            {/* FormRow hides the label column below `lg`, so the hint and
+                guide link are repeated here for narrow viewports — same
+                pattern as the main-image row's format note. */}
+            <p className="mt-2 text-[13px] text-gray-600 lg:hidden">
+              {trackingMethodHint}{" "}
+              <TrackingMethodGuideLink isEditMode={isEditMode} />
+            </p>
           </FormRow>
         </When>
 
@@ -1509,6 +1501,28 @@ function BulkCreatePreview({ titles }: { titles: string[] }) {
  */
 const TRACKING_METHOD_KB_URL =
   "https://www.shelf.nu/knowledge-base/how-to-choose-a-tracking-method";
+
+/**
+ * Link into that guide. Create mode opens the decision guide itself; edit
+ * mode opens its "what you can and cannot change later" section, since the
+ * method is locked by then and the question is what to do about it.
+ */
+function TrackingMethodGuideLink({ isEditMode }: { isEditMode: boolean }) {
+  return (
+    <Button
+      to={
+        isEditMode
+          ? `${TRACKING_METHOD_KB_URL}#what-you-can-and-cannot-change-later`
+          : TRACKING_METHOD_KB_URL
+      }
+      variant="link-gray"
+      className="text-gray-600 underline"
+      target="_blank"
+    >
+      {isEditMode ? "Picked the wrong one?" : "Which should I pick?"}
+    </Button>
+  );
+}
 
 /** Radio card options for the tracking method selector. */
 const TRACKING_OPTIONS = [

--- a/apps/webapp/app/components/assets/form.tsx
+++ b/apps/webapp/app/components/assets/form.tsx
@@ -816,9 +816,32 @@ export const AssetForm = ({
             rowLabel={"Tracking method"}
             className="border-b-0 pb-[10px]"
             subHeading={
-              isEditMode
-                ? "Tracking method cannot be changed after creation."
-                : "Choose how this asset is tracked. This cannot be changed later."
+              isEditMode ? (
+                <p>
+                  Tracking method cannot be changed after creation.{" "}
+                  <Button
+                    to={`${TRACKING_METHOD_KB_URL}#what-you-can-and-cannot-change-later`}
+                    variant="link-gray"
+                    className="text-gray-600 underline"
+                    target="_blank"
+                  >
+                    Picked the wrong one?
+                  </Button>
+                </p>
+              ) : (
+                <p>
+                  Choose how this asset is tracked. This cannot be changed
+                  later.{" "}
+                  <Button
+                    to={TRACKING_METHOD_KB_URL}
+                    variant="link-gray"
+                    className="text-gray-600 underline"
+                    target="_blank"
+                  >
+                    Which should I pick?
+                  </Button>
+                </p>
+              )
             }
             required={true}
           >
@@ -1479,6 +1502,13 @@ function BulkCreatePreview({ titles }: { titles: string[] }) {
     </div>
   );
 }
+
+/**
+ * Knowledge-base guide behind the tracking-method row: the individual /
+ * model / quantity decision, and what can still change after creation.
+ */
+const TRACKING_METHOD_KB_URL =
+  "https://www.shelf.nu/knowledge-base/how-to-choose-a-tracking-method";
 
 /** Radio card options for the tracking method selector. */
 const TRACKING_OPTIONS = [


### PR DESCRIPTION
## What

The asset form's "Tracking method" row said the choice is permanent but gave no way to learn which method to pick, and the app never linked the knowledge-base guide that answers that question (no route or component references it). People choosing between individual and quantity tracking had to guess, and anyone who guessed wrong later landed on an edit form that only said "cannot be changed".

## Changes

`apps/webapp/app/components/assets/form.tsx`

- Create mode: the sub-heading now ends with a **Which should I pick?** link to https://www.shelf.nu/knowledge-base/how-to-choose-a-tracking-method (new tab).
- Edit mode: "Tracking method cannot be changed after creation." now ends with a **Picked the wrong one?** link to the guide's "What you can and cannot change later" section, which walks through the pool-to-units path.
- Same `Button variant="link-gray"` + `target="_blank"` shape as the "Create categories" link a few rows down in the same form. `rel="noopener noreferrer"` comes from the Button's new-tab guard, as everywhere else.
- The URL lives in one module constant next to the tracking options.
- Bulk-create mode is unchanged; the row is not rendered there.
- Narrow viewports: FormRow hides its label column below `lg`, so the hint and link are also rendered under the cards in a `lg:hidden` paragraph, the same pattern the main-image row uses for its format note. One shared `TrackingMethodGuideLink` component keeps the copy and URLs in one place.

## Verification

- `pnpm webapp:validate` passes (tests, lint, typecheck).
- Browser check on a local dev server against the QA workspace: the create form shows the link and opens the guide in a new tab with `rel="noopener noreferrer"`; the edit form of a quantity-tracked asset shows the edit-mode link, landing on the section anchor. Both forms checked at 375px (link under the cards) and at desktop width (link in the sub-heading only).
- React Doctor's four advisory warnings on `form.tsx` (8 `useState` calls, component length, two `referer` initializers) all pre-date this change, which adds one constant and one small component and no state; splitting the form is out of scope here.
