### PR TITLE
fix(bookings): give kit-driven quantity rows no stock badge

### DIFF
--- a/apps/webapp/app/components/booking/booking-assets-sidebar.test.tsx
+++ b/apps/webapp/app/components/booking/booking-assets-sidebar.test.tsx
@@ -212,6 +212,45 @@ describe("BookingAssetsSidebar QT stock badges", () => {
     expect(trigger).toHaveClass("bg-red-50");
   });
 
+  it("renders no stock badge for a kit-driven row even when the loose pool is empty", async () => {
+    // A kit holding the asset's last units: the loose pool reads 0/0, and the
+    // row is booked through the kit (`assetKitId` set), so neither badge
+    // applies. The same figures on a standalone row are the red case above.
+    const kit = {
+      id: "kit-1",
+      name: "Projector case",
+      image: null,
+      imageExpiration: null,
+      category: null,
+    };
+    const asset = makeQtAsset({ assetKits: [{ id: "ak-1", kit }] });
+    const booking = makeBooking({ status: "RESERVED" });
+    fetcher.data = {
+      ...makePayload({ asset, bookedQuantity: 1 }),
+      bookingAssets: [{ id: "ba-kit", quantity: 1, assetKitId: "ak-1", asset }],
+    };
+
+    render(
+      <BookingAssetsSidebar
+        booking={booking}
+        availableUnitsByAsset={{
+          [asset.id]: { bookable: 0, physicalNow: 0, reserved: 0 },
+        }}
+      />
+    );
+
+    await openSidebar();
+
+    // Kit groups start collapsed; the member row only exists once expanded.
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Toggle kit expand" })
+    );
+
+    expect(await screen.findByText("Boards")).toBeInTheDocument();
+    expect(screen.queryByText("Insufficient stock")).not.toBeInTheDocument();
+    expect(screen.queryByText("Checked out elsewhere")).not.toBeInTheDocument();
+  });
+
   it("renders the amber PendingReturnBadge on a not-started booking when rowQty fits bookable but exceeds physicalNow, with an explanatory tooltip", async () => {
     // "Boards" real case: 10 total, 7 needed; 7 return before this RESERVED
     // booking's window opens (bookable=10) but only 3 are on the shelf

--- a/apps/webapp/app/components/booking/booking-assets-sidebar.tsx
+++ b/apps/webapp/app/components/booking/booking-assets-sidebar.tsx
@@ -283,6 +283,13 @@ type SidebarAsset = SidebarAssetBase & {
   bookedQuantity: number;
   kit: NonNullable<SidebarAssetBase["assetKits"][number]["kit"]> | null;
   kitId: string | null;
+  /**
+   * Live kit-driven slice (`BookingAsset.assetKitId` set). Its units come
+   * out of the kit's allocation, not the loose pool, so the stock badges
+   * skip it. Read off the pivot row rather than `kitId`, which also stays
+   * null when the membership cannot be resolved for display.
+   */
+  isKitDriven: boolean;
 };
 
 /**
@@ -322,6 +329,7 @@ function groupAssets(bookingAssets: BookingWithAssets["bookingAssets"]) {
       bookedQuantity: ba.quantity,
       kit: sourceKit,
       kitId: sourceKit?.id ?? null,
+      isKitDriven: ba.assetKitId != null,
     };
     if (asset.kitId && asset.kit) {
       const kitId = asset.kitId;
@@ -479,6 +487,7 @@ function AssetTitleAndStatus({
     availability,
     contextStatus: effectiveStatus,
     bookingStatus,
+    isKitDriven: asset.isKitDriven,
   });
 
   return (

--- a/apps/webapp/app/components/booking/kit-row.tsx
+++ b/apps/webapp/app/components/booking/kit-row.tsx
@@ -183,10 +183,11 @@ export default function KitRow({
           Per the code-bearing-entity-list-consistency rule, badges
           live on the expanded asset child rows (kit-row delegates to
           ListAssetContent via the loop below). A live kit-driven child
-          gets no stock badge there either: its units are bounded by
-          the kit's allocation, not the loose pool. Only a detached
-          child (`isRemovedFromKit`) is measured like a standalone
-          slice. The kit header itself only surfaces the "Already
+          (`assetKitId` set, so `isKitDriven`) gets no stock badge
+          there either: its units are bounded by the kit's allocation,
+          not the loose pool. Only a child whose slice no longer points
+          at a membership (`assetKitId` null) is measured like a
+          standalone slice. The kit header itself only surfaces the "Already
           booked" overlap signal and an asset count; it has no
           aggregate stock or per-unit booking semantics of its own,
           so no insufficient-stock badge belongs here.

--- a/apps/webapp/app/components/booking/kit-row.tsx
+++ b/apps/webapp/app/components/booking/kit-row.tsx
@@ -180,12 +180,15 @@ export default function KitRow({
 
         {/*
           why: out of this rule — kit header has no status badge.
-          Per the code-bearing-entity-list-consistency rule, the
-          per-row InsufficientStockBadge fires inside ListAssetContent
-          for each expanded QT asset child (kit-row delegates to it
-          via the loop below). The kit header itself only surfaces the
-          "Already booked" overlap signal and an asset count; it has
-          no aggregate stock or per-unit booking semantics of its own,
+          Per the code-bearing-entity-list-consistency rule, badges
+          live on the expanded asset child rows (kit-row delegates to
+          ListAssetContent via the loop below). A live kit-driven child
+          gets no stock badge there either: its units are bounded by
+          the kit's allocation, not the loose pool. Only a detached
+          child (`isRemovedFromKit`) is measured like a standalone
+          slice. The kit header itself only surfaces the "Already
+          booked" overlap signal and an asset count; it has no
+          aggregate stock or per-unit booking semantics of its own,
           so no insufficient-stock badge belongs here.
         */}
         <Td>

--- a/apps/webapp/app/components/booking/list-asset-content.test.tsx
+++ b/apps/webapp/app/components/booking/list-asset-content.test.tsx
@@ -563,6 +563,49 @@ describe("ListAssetContent", () => {
       expect(tooltip.textContent).toMatch(/only 3/);
     });
 
+    it("renders no stock badge for a kit-driven QT row even when the loader reports no loose units", () => {
+      // A kit holding the asset's last units: the loose pool is 0/0, and the
+      // row is booked through the kit, so neither the red nor the amber badge
+      // applies. The same numbers on a standalone row are test (c)'s red case.
+      const kitRow = {
+        ...qtCheckedOutAsset,
+        status: "AVAILABLE",
+        bookedQuantity: 1,
+        isKitDriven: true,
+      } as unknown as AssetWithBooking;
+      mockUseLoaderData.mockReturnValue({
+        booking: {
+          id: "booking-reserved-kit",
+          status: "RESERVED",
+          bookingAssets: [{ assetId: kitRow.id }],
+          custodianUser: null,
+        },
+        availableUnitsByAsset: { [kitRow.id]: { bookable: 0, physicalNow: 0 } },
+      });
+
+      render(
+        <table>
+          <tbody>
+            <tr>
+              <ListAssetContent
+                item={kitRow}
+                isKitAsset
+                partialCheckinDetails={basePartialDetails}
+                shouldShowCheckinColumns={false}
+                partialCheckoutDetails={{}}
+                shouldShowCheckoutColumns={false}
+              />
+            </tr>
+          </tbody>
+        </table>
+      );
+
+      expect(screen.queryByText("Insufficient stock")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Checked out elsewhere")
+      ).not.toBeInTheDocument();
+    });
+
     it("still renders the amber 'Checked out' AvailabilityBadge for an INDIVIDUAL row whose asset is checked out elsewhere", () => {
       // (d) — Regression guard: the QT short-circuits MUST NOT affect the
       // INDIVIDUAL path. An INDIVIDUAL asset with global CHECKED_OUT status

--- a/apps/webapp/app/components/booking/list-asset-content.test.tsx
+++ b/apps/webapp/app/components/booking/list-asset-content.test.tsx
@@ -573,6 +573,8 @@ describe("ListAssetContent", () => {
         bookedQuantity: 1,
         isKitDriven: true,
       } as unknown as AssetWithBooking;
+      // why: the loader map reports zero loose-pool units for this asset, the
+      // figure that would light the red badge on a standalone row.
       mockUseLoaderData.mockReturnValue({
         booking: {
           id: "booking-reserved-kit",

--- a/apps/webapp/app/components/booking/list-asset-content.tsx
+++ b/apps/webapp/app/components/booking/list-asset-content.tsx
@@ -240,14 +240,18 @@ export default function ListAssetContent({
    *    or (partially) fulfilled (`contextStatus`, computed above) — at
    *    that point the stock signal has nothing left to warn about for it.
    *
-   * Each row evaluates independently against the SAME per-asset workspace
-   * headroom, so a multi-row asset can have several rows each light up.
+   * Each standalone row evaluates independently against the SAME per-asset
+   * workspace headroom, so a multi-row asset can have several rows each
+   * light up. A kit-driven row (`item.isKitDriven`) gets neither badge: its
+   * units are bounded by the kit's allocation, which that headroom already
+   * excludes.
    */
   const stockBadgeVariant = resolveQtyStockBadgeVariant({
     rowQty: qtyBooked,
     availability,
     contextStatus,
     bookingStatus: booking.status,
+    isKitDriven: Boolean(item.isKitDriven),
   });
 
   // Per-asset partial check-OUT record (if any). Presence of a record drives

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
@@ -1,3 +1,14 @@
+/**
+ * Booking "Add assets" picker: `/bookings/:bookingId/overview/manage-assets`.
+ *
+ * The loader lists the workspace's assets for the picker (paginated and
+ * filterable) with each row's fitness for THIS booking: kit membership that
+ * blocks a direct add, overlap with other bookings, and the windowed
+ * free-unit count for quantity-tracked assets. The action writes the
+ * selection to the booking through `updateBookingAssets`, which owns the
+ * conflict and quantity guards. Also exports `AssetWithBooking`, the row
+ * shape the booking overview list renders.
+ */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   Asset,

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
@@ -179,6 +179,14 @@ export type AssetWithBooking = Asset & {
    * bookings ever see it). Absent on surfaces that don't project it.
    */
   isRemovedFromKit?: boolean | null;
+  /**
+   * True when this row is a live kit-driven slice (`BookingAsset.assetKitId`
+   * set): its units come out of the kit's allocation (`AssetKit.quantity`),
+   * not the loose pool, so the workspace-availability stock badges do not
+   * apply to it. Resolved by the booking-overview loader; absent on surfaces
+   * that don't project it.
+   */
+  isKitDriven?: boolean | null;
   // Pickup location rendered in the booking Location column. On the
   // pivot model this comes from `assetLocations[0].location` via the
   // loader's `getPrimaryLocation` normalisation.

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -676,6 +676,14 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         bookingAssetId: ba.id,
         bookedQuantity: ba.quantity ?? 1,
         isRemovedFromKit,
+        /**
+         * Live kit-driven slice (`BookingAsset.assetKitId` set): the row's
+         * units come out of the kit's allocation, not the loose pool, so the
+         * workspace-availability badges skip it (`resolveQtyStockBadgeVariant`).
+         * Derived here for the same reason as `isRemovedFromKit`: the cached
+         * row projection does not carry `assetKitId`.
+         */
+        isKitDriven: ba.assetKitId != null,
       };
     });
 
@@ -988,6 +996,9 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
      * "pending return" badge (fires on not-yet-started bookings when
      * `bookedQuantity` exceeds `.physicalNow` while still fitting within
      * `.bookable`) on the booking-overview asset row + assets sidebar.
+     * Both figures describe the LOOSE pool: kit allocations are already
+     * subtracted, so kit-driven rows (`isKitDriven`) never compare against
+     * them.
      *
      * Delegates to the shared, windowed QT availability primitive via
      * `buildAvailableUnitsByAsset` — see

--- a/apps/webapp/app/utils/booking-assets.test.ts
+++ b/apps/webapp/app/utils/booking-assets.test.ts
@@ -503,6 +503,31 @@ describe("resolveQtyStockBadgeVariant", () => {
     ).toBeNull();
   });
 
+  it("(e) returns null for a kit-driven row even when rowQty exceeds both figures, while the same standalone row warns", () => {
+    expect.assertions(2);
+    // A kit holding the asset's last units: the loose pool reads 0/0 because
+    // the kit's allocation is already subtracted from both figures.
+    const kitAvailability = { bookable: 0, physicalNow: 0 };
+    expect(
+      resolveQtyStockBadgeVariant({
+        rowQty: 1,
+        availability: kitAvailability,
+        contextStatus: AssetStatus.AVAILABLE,
+        bookingStatus: BookingStatus.RESERVED,
+        isKitDriven: true,
+      })
+    ).toBeNull();
+    expect(
+      resolveQtyStockBadgeVariant({
+        rowQty: 1,
+        availability: kitAvailability,
+        contextStatus: AssetStatus.AVAILABLE,
+        bookingStatus: BookingStatus.RESERVED,
+        isKitDriven: false,
+      })
+    ).toBe("insufficient");
+  });
+
   it("does not warn amber once the booking has started (ONGOING/OVERDUE) even if rowQty exceeds physicalNow", () => {
     expect.assertions(2);
     // Row itself hasn't drawn from the pool yet (still AVAILABLE

--- a/apps/webapp/app/utils/booking-assets.ts
+++ b/apps/webapp/app/utils/booking-assets.ts
@@ -747,6 +747,13 @@ export type QtyStockAvailability = {
  * comparisons. RED is checked before AMBER — a genuine over-commit is
  * always the more actionable signal.
  *
+ * A kit-driven row (`BookingAsset.assetKitId` set) gets neither badge. Its
+ * units come out of the kit's own allocation (`AssetKit.quantity`), which
+ * `bookable` and `physicalNow` already subtract via `inKits`; measured
+ * against the loose pool it would read as short whenever the kit holds the
+ * asset's last units. The reserve and check-out guards skip these rows on
+ * the same `assetKitId IS NULL` predicate, so the badge and the guards agree.
+ *
  * @param args.rowQty - This row's booked quantity.
  * @param args.availability - The asset's workspace-availability figures, or
  *   `undefined` when the loader didn't ship the map (e.g. INDIVIDUAL assets,
@@ -755,17 +762,22 @@ export type QtyStockAvailability = {
  *   (`contextStatus` / `effectiveStatus`) — feeds
  *   {@link isQtyRowCheckedOutOrFulfilled}.
  * @param args.bookingStatus - The parent booking's status.
+ * @param args.isKitDriven - Whether the row is a kit-driven slice
+ *   (`BookingAsset.assetKitId` set). Callers that render kit members pass
+ *   it; it defaults to `false` for surfaces that only show loose rows.
  */
 export function resolveQtyStockBadgeVariant({
   rowQty,
   availability,
   contextStatus,
   bookingStatus,
+  isKitDriven = false,
 }: {
   rowQty: number;
   availability: QtyStockAvailability | undefined;
   contextStatus: string;
   bookingStatus: string;
+  isKitDriven?: boolean;
 }): "insufficient" | "pending-return" | null {
   if (!availability) return null;
 
@@ -780,6 +792,10 @@ export function resolveQtyStockBadgeVariant({
   if (isQtyRowCheckedOutOrFulfilled(contextStatus)) {
     return null;
   }
+
+  // Bounded by the kit's allocation, not by the loose pool the figures
+  // below describe.
+  if (isKitDriven) return null;
 
   // Strict inequality — at-capacity is NOT a problem.
   if (rowQty > availability.bookable) {


### PR DESCRIPTION
## The report

A customer on Discord adds a kit (a projector case: one projector, a quantity-tracked remote, two quantity-tracked clamps) to a booking on the web. The kit is added, but the remote and the clamps show the red **Insufficient stock** badge inside the booking. The remote's own page shows `Total 2, Available 0, In kits 2`: every unit lives inside kits. Screenshots in the thread.

## Root cause

`resolveQtyStockBadgeVariant` (`app/utils/booking-assets.ts`) compares every quantity-tracked row against `availableUnitsByAsset[assetId].bookable` and `.physicalNow`. Both figures describe the **loose pool**: `getAssetAvailabilityBatch` subtracts kit allocations via `inKits` before it reports them (`bookable = total − inCustody − inKits − reserved`, `asset/availability.server.ts`).

A kit-driven row (`BookingAsset.assetKitId` set) does not draw on that pool. Its units come out of the kit's own allocation (`AssetKit.quantity`), which is exactly what was subtracted. So a kit whose members have no loose units reads as `requested 1, only 0 available` on both the booking list and the assets sidebar, for every one of its quantity-tracked members.

The write paths already know this: the reserve guard in `updateBookingAssets` and the check-out guard in `checkoutBookingWritesWithinTx` both filter on `assetKitId == null` before calling `assertAssetQuantitiesAvailable`. Reserving and checking out such a booking works. Only the badge disagreed with them.

## The fix

The badge resolver takes `isKitDriven` and returns `null` for kit-driven rows, on the same `assetKitId IS NULL` predicate the guards use. Both callers pass it:

- **Booking overview list**: the loader marks each slice `isKitDriven: ba.assetKitId != null` next to `isRemovedFromKit` (the cached row projection does not carry `assetKitId`, so it is derived server-side like that flag). `AssetWithBooking` gains the optional field; `list-asset-content.tsx` forwards it.
- **Assets sidebar**: `groupAssets` reads it off the pivot row into `SidebarAsset` and the row forwards it. Read from the pivot rather than `kitId`, which also stays null when a membership cannot be resolved for display.

A row that was booked through a kit and later detached (`assetKitId` set NULL by the membership delete, `sourceKitId` kept) is **not** exempt: its units are back in the loose pool, and the reserve guard measures it there too.

No migration, no schema change, no API change.

## Not in this PR

- The phone's add-to-booking route flattens a scanned kit into loose asset ids, so the same customer gets a hard error on the phone (`requested 1, only 0 of 2 units available`). #3004 fixes that route.
- A kit made only of quantity-tracked assets has no kit-level overlap guard: `hasAssetBookingConflicts` checks INDIVIDUAL members. Two overlapping bookings can each hold such a kit today, and neither surface warns. Separate question, not changed here.

## Tests

- `booking-assets.test.ts`: kit-driven row with `bookable: 0` → `null`; the same standalone row → `"insufficient"`.
- `list-asset-content.test.tsx`: kit member row with a 0/0 pool renders neither badge.
- `booking-assets-sidebar.test.tsx`: kit group expanded, member row with a 0/0 pool renders neither badge.

All three fail with the exemption removed. `pnpm webapp:validate`: typecheck clean, lint clean, 6008 tests passing. Three route-test files hit vitest's 10 s hook timeout while the pre-commit typecheck ran alongside the suite; each passes on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kit-based assets no longer display misleading “Insufficient stock” or “Checked out elsewhere” badges based on loose inventory availability.
  * Standalone assets continue to show stock-availability badges when applicable.
  * Stock indicators now reflect whether an asset is supplied through a kit allocation or the loose inventory pool.

* **Tests**
  * Added coverage confirming correct badge behavior for kit-driven and standalone quantity-tracked assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->