### PR TITLE
fix(kits): flatten AssetKit pivot in /api/kits payload

### DIFF
--- a/.claude/rules/api-payload-contracts-need-a-test-on-both-sides.md
+++ b/.claude/rules/api-payload-contracts-need-a-test-on-both-sides.md
@@ -1,0 +1,74 @@
+---
+description: A typed cast at an I/O boundary is a claim, not a contract — pin producer and consumer with tests
+globs:
+  [
+    "apps/webapp/app/routes/api+/**/*.ts",
+    "apps/webapp/app/routes/api+/**/*.tsx",
+    "apps/webapp/app/components/**/*.tsx",
+    "apps/webapp/app/hooks/**/*.ts",
+  ]
+---
+
+# An API Payload Type Is A Claim, Not A Contract
+
+`useApiQuery<TData>` casts `response.json()` to its type parameter with **no
+runtime validation**. The declared type describes what the consumer _hopes_
+arrives. Nothing compares it to what the route actually sends, so the compiler
+cannot see producer/consumer drift — and neither can review, lint or CI.
+
+Three places in this repo erase the compiler the same way:
+
+| Boundary                                            | Why tsc is blind                                     |
+| --------------------------------------------------- | ---------------------------------------------------- |
+| `useApiQuery<T>` / any `await res.json() as T`      | the cast is asserted, never checked                  |
+| `Prisma.sql` + `$queryRaw<T>`                       | the SQL is a string; `T` is user-supplied            |
+| `ListItemData` (`{ id: string; [x: string]: any }`) | an index signature types every field access as `any` |
+
+## The two failure shapes — the quiet one is worse
+
+Change what a route returns without changing its consumer and you get one of:
+
+- **A crash.** `kit.assets` is `undefined`, `kit.assets.length` throws. Loud,
+  but it can take a whole page down: children of a Radix `PopoverContent` are
+  evaluated during the parent's own render, so the throw reaches the route
+  `ErrorBoundary` before anyone opens the popover.
+- **A silently wrong answer.** The same read behind `?.` never throws — it just
+  evaluates `false` forever. A guard that never fires looks exactly like a guard
+  with nothing to catch.
+
+Both shipped from one commit (`266425e39`, the `AssetKit` pivot): the kits
+popover crashed the booking activity page, and the kits bulk-actions custody
+guard silently stopped firing.
+
+## What to do
+
+1. **Pin both sides.** The route test asserts the shape the route emits; a
+   consumer test feeds a fixture of that same shape. Either alone goes green
+   over a broken pair. Verify the producer test actually **fails** against the
+   old payload — a regression test you never saw red is a guess.
+2. **Give the compiler something to check.** When rows arrive as `any`
+   (`ListItemData`), read them through a function with a declared parameter
+   type instead of destructuring inline. A typed parameter turns a renamed
+   field into a build error; an inline `row.whatever` never will.
+3. **Never reach for `?.` or `?? []` to make a drift stop crashing.** That
+   converts a caught bug into a permanent wrong answer. Fix the contract.
+
+```ts
+// ❌ Bad — the type is a claim; nothing checks it, and `?.` hides the drift
+const { data } = useApiQuery<{ kits: Kit[] }>({ api: "/api/kits" });
+const blocked = rows.some((kit) => kit.assets?.some((a) => a.status === "X"));
+
+// ✅ Good — the route flattens to the shape the consumer declares, and the
+// predicate takes a typed row so the field name is compiler-checked
+export function someKitMemberBlocksCustodyAssignment(
+  kits: { assetKits?: { asset: { status: AssetStatus } }[] }[]
+): boolean { … }
+```
+
+When you change an `api+` route's payload, grep its consumers before you
+commit — `useApiQuery` will not tell you, and neither will `pnpm webapp:validate`.
+
+Related: [[raw-sql-respects-prisma-map]] for the same "a return-type cast is not
+a contract" trap in raw SQL, and
+[[hand-written-projections-drop-relation-fields]] for the projection that
+silently drops a field the select did fetch.

--- a/apps/webapp/app/components/kits/bulk-actions-dropdown.tsx
+++ b/apps/webapp/app/components/kits/bulk-actions-dropdown.tsx
@@ -1,4 +1,3 @@
-import type { AssetStatus } from "@prisma/client";
 import { useAtomValue } from "jotai";
 import { useNavigation } from "react-router";
 import { useHydrated } from "remix-utils/use-hydrated";
@@ -7,6 +6,7 @@ import { useControlledDropdownMenu } from "~/hooks/use-controlled-dropdown-menu"
 import { useUserData } from "~/hooks/use-user-data";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import { isFormProcessing } from "~/utils/form";
+import { someKitMemberBlocksCustodyAssignment } from "~/utils/kits";
 import { isSelectingAllItems } from "~/utils/list";
 import {
   PermissionAction,
@@ -85,15 +85,8 @@ function ConditionalDropdown() {
     (kit) => kit.status === "CHECKED_OUT"
   );
 
-  const someAssetsInsideKitsCheckedOutOrInCustody = selectedKits.some(
-    (kit) =>
-      kit.assets?.some(
-        (asset: { status: AssetStatus }) => asset.status === "CHECKED_OUT"
-      ) ||
-      kit.assets?.some(
-        (asset: { status: AssetStatus }) => asset.status === "IN_CUSTODY"
-      )
-  );
+  const someAssetsInsideKitsCheckedOutOrInCustody =
+    someKitMemberBlocksCustodyAssignment(selectedKits);
 
   const disabled = selectedKits.length === 0;
 

--- a/apps/webapp/app/components/kits/bulk-actions-dropdown.tsx
+++ b/apps/webapp/app/components/kits/bulk-actions-dropdown.tsx
@@ -70,9 +70,12 @@ function ConditionalDropdown() {
   const user = useUserData();
 
   /**
-   * Due to select all multi page selection,
-   * some of the checks we do cannot be completed as we dont have the data loaded from the server.
-   * As a solution for now we will handle the validation serverSide if hasSelectedAll is true
+   * "Select all" spans every page of the list, so when `allSelected` is true
+   * the selection includes rows this client never loaded and the checks below
+   * cannot be completed from what it holds. They resolve permissively in that
+   * case and the server re-validates the request. Every guard here is an
+   * affordance that explains why an action is unavailable — never the
+   * enforcement.
    */
 
   const allKitsInCustody =

--- a/apps/webapp/app/components/markdown/kits-list-component.test.tsx
+++ b/apps/webapp/app/components/markdown/kits-list-component.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { KitsListComponent } from "./kits-list-component";
+
+/**
+ * The payload `/api/kits` serialises, as the component receives it.
+ *
+ * `useApiQuery` casts the response to the component's `Kit` type without
+ * validating it, so a route that stops sending a field hands the component
+ * `undefined` and the compiler stays silent — the popover then dies on the
+ * first property read, taking the whole activity page down with it. This
+ * fixture is the contract between the two: change `app/routes/api+/kits.tsx`
+ * and change it here.
+ */
+const apiKitsPayload = {
+  kits: [
+    {
+      id: "kit-1",
+      name: "Camera Kit",
+      image: null,
+      imageExpiration: null,
+      assets: [
+        {
+          id: "asset-1",
+          title: "Sony FX3",
+          mainImage: null,
+          mainImageExpiration: null,
+          thumbnailImage: null,
+          imageSource: "placeholder",
+          category: { name: "Cameras" },
+        },
+      ],
+    },
+    {
+      id: "kit-2",
+      name: "Audio Kit",
+      image: null,
+      imageExpiration: null,
+      assets: [],
+    },
+  ],
+};
+
+// why: the hook fetches in an effect; stubbing it keeps these tests on how the
+// component renders a known payload rather than on network behaviour.
+const { useApiQueryMock } = vi.hoisted(() => ({ useApiQueryMock: vi.fn() }));
+
+vi.mock("~/hooks/use-api-query", () => ({ default: useApiQueryMock }));
+
+// why: both image components open their own signed-URL refresh fetchers, which
+// need a data-router context. They have their own tests; stubbing them keeps
+// this one on the kit/asset list the popover builds.
+vi.mock("~/components/kits/kit-image", () => ({
+  default: ({ kit }: { kit: { alt: string } }) => <img alt={kit.alt} />,
+}));
+vi.mock("~/components/assets/asset-image/component", () => ({
+  AssetImage: ({ alt }: { alt: string }) => <img alt={alt} />,
+}));
+
+// why: `Button` renders a react-router `Link` for internal targets, which needs
+// router context.
+const renderComponent = (count: number, ids: string) =>
+  render(
+    <MemoryRouter>
+      <KitsListComponent count={count} ids={ids} action="added" />
+    </MemoryRouter>
+  );
+
+describe("KitsListComponent", () => {
+  beforeEach(() => {
+    useApiQueryMock.mockReturnValue({
+      data: apiKitsPayload,
+      isLoading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    });
+  });
+
+  it("renders the kit count trigger for a multi-kit note", () => {
+    renderComponent(2, "kit-1,kit-2");
+
+    expect(screen.getByRole("button", { name: "2 kits" })).toBeVisible();
+  });
+
+  it("lists every kit with its member assets when opened", async () => {
+    const user = userEvent.setup();
+    renderComponent(2, "kit-1,kit-2");
+
+    await user.click(screen.getByRole("button", { name: "2 kits" }));
+
+    expect(await screen.findByText("Camera Kit")).toBeVisible();
+    expect(screen.getByText("Audio Kit")).toBeVisible();
+    expect(screen.getByText("Sony FX3")).toBeVisible();
+    expect(screen.getByText("(Cameras)")).toBeVisible();
+  });
+
+  it("counts each kit's member assets", async () => {
+    const user = userEvent.setup();
+    renderComponent(2, "kit-1,kit-2");
+
+    await user.click(screen.getByRole("button", { name: "2 kits" }));
+
+    expect(await screen.findByText("(1 assets)")).toBeVisible();
+    expect(screen.getByText("(0 assets)")).toBeVisible();
+  });
+
+  it("links straight to the kit for a single-kit note", () => {
+    renderComponent(1, "kit-1");
+
+    expect(screen.getByRole("link", { name: "Camera Kit" })).toHaveAttribute(
+      "href",
+      "/kits/kit-1"
+    );
+  });
+
+  it("renders the trigger without member data before the popover is opened", () => {
+    // The popover's children are built during this component's own render, so
+    // an unopened popover still evaluates them — a payload it cannot read
+    // crashes the page without anyone clicking.
+    useApiQueryMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    });
+
+    renderComponent(3, "kit-1,kit-2,kit-3");
+
+    expect(screen.getByRole("button", { name: "3 kits" })).toBeVisible();
+  });
+});

--- a/apps/webapp/app/components/markdown/kits-list-component.test.tsx
+++ b/apps/webapp/app/components/markdown/kits-list-component.test.tsx
@@ -42,18 +42,22 @@ const apiKitsPayload = {
   ],
 };
 
-// why: the hook fetches in an effect; stubbing it keeps these tests on how the
-// component renders a known payload rather than on network behaviour.
 const { useApiQueryMock } = vi.hoisted(() => ({ useApiQueryMock: vi.fn() }));
 
+// why: the hook fetches in an effect; stubbing it keeps these tests on how the
+// component renders a known payload rather than on network behaviour.
 vi.mock("~/hooks/use-api-query", () => ({ default: useApiQueryMock }));
 
-// why: both image components open their own signed-URL refresh fetchers, which
-// need a data-router context. They have their own tests; stubbing them keeps
-// this one on the kit/asset list the popover builds.
+// why: KitImage opens its own signed-URL refresh fetcher, which needs a data
+// router context. It has its own tests; stubbing it keeps this one on the kit
+// list the popover builds.
 vi.mock("~/components/kits/kit-image", () => ({
   default: ({ kit }: { kit: { alt: string } }) => <img alt={kit.alt} />,
 }));
+
+// why: AssetImage resolves the model image cascade and refreshes signed URLs
+// through its own fetcher, which needs a data router context. Stubbing it keeps
+// this one on the member assets the popover lists.
 vi.mock("~/components/assets/asset-image/component", () => ({
   AssetImage: ({ alt }: { alt: string }) => <img alt={alt} />,
 }));

--- a/apps/webapp/app/components/markdown/kits-list-component.tsx
+++ b/apps/webapp/app/components/markdown/kits-list-component.tsx
@@ -36,15 +36,22 @@ interface Asset {
   };
 }
 
+/**
+ * One kit as `/api/kits` serialises it.
+ *
+ * `useApiQuery` casts the response to this type without validating it, so the
+ * compiler cannot tell a drifting payload from a matching one — a field the
+ * route stops sending arrives as `undefined` and only crashes at render. Change
+ * this shape and `app/routes/api+/kits.tsx` together, and keep
+ * `kits-list-component.test.tsx` fed with the route's real payload.
+ */
 interface Kit {
   id: string;
   name: string;
   image?: string;
   imageExpiration?: string;
+  /** Member assets, flattened out of the `AssetKit` pivot by the route. */
   assets: Asset[];
-  _count: {
-    assets: number;
-  };
 }
 
 export function KitsListComponent({

--- a/apps/webapp/app/routes/api+/kits.tsx
+++ b/apps/webapp/app/routes/api+/kits.tsx
@@ -69,11 +69,6 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
           },
           orderBy: { asset: { title: "asc" } },
         },
-        _count: {
-          select: {
-            assetKits: true,
-          },
-        },
       },
       orderBy: {
         name: "asc",
@@ -81,18 +76,19 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
     });
 
     /**
-     * Resolve each member asset's image cascade server-side so the note's kit
-     * popover shows the model's cover image for assets without one of their
-     * own. See `serializeAssetImage`.
+     * Kit membership is stored as `AssetKit` pivot rows, but the popover only
+     * ever needs the member assets themselves — so the pivot is flattened away
+     * here and the wire shape stays a plain `assets` array. Each asset's image
+     * cascade is resolved server-side too, so the popover shows the model's
+     * cover image for assets without one of their own (`serializeAssetImage`).
      */
     return data(
       payload({
-        kits: kits.map((kit) => ({
+        kits: kits.map(({ assetKits, ...kit }) => ({
           ...kit,
-          assetKits: kit.assetKits.map((assetKit) => ({
-            ...assetKit,
-            asset: serializeAssetImage(assetKit.asset),
-          })),
+          assets: assetKits.map((assetKit) =>
+            serializeAssetImage(assetKit.asset)
+          ),
         })),
       })
     );

--- a/apps/webapp/app/utils/kits.test.ts
+++ b/apps/webapp/app/utils/kits.test.ts
@@ -1,17 +1,26 @@
+/**
+ * Tests for the kit list row helpers.
+ *
+ * The rows these helpers read reach the UI through `selectedBulkItemsAtom`,
+ * which types every field as `any`, so the compiler cannot tell a helper that
+ * reads the right field from one that reads a field the loader never sends.
+ * These assertions are that check.
+ *
+ * @see {@link file://./kits.ts}
+ */
+
 import type { AssetStatus } from "@prisma/client";
 import { someKitMemberBlocksCustodyAssignment } from "./kits";
 
+let nextKitId = 0;
+
 /**
- * Kit list rows exactly as the kits index loader supplies them.
- *
- * Membership arrives as `AssetKit` pivot rows — `assetKits[].asset` — and the
- * rows reach the consumer through `selectedBulkItemsAtom`, which types every
- * field as `any`. That makes these assertions the only check that the guard
- * reads the field the loader actually sends.
+ * Builds a kit list row carrying the given member statuses, shaped exactly as
+ * the kits index loader supplies it — membership as `AssetKit` pivot rows
+ * (`assetKits[].asset`), never a flat asset array.
  *
  * @see {@link file://./../routes/_layout+/kits._index.tsx}
  */
-let nextKitId = 0;
 const kitRow = (...statuses: AssetStatus[]) => ({
   id: `kit-${(nextKitId += 1)}`,
   assetKits: statuses.map((status) => ({ asset: { status } })),

--- a/apps/webapp/app/utils/kits.test.ts
+++ b/apps/webapp/app/utils/kits.test.ts
@@ -1,0 +1,66 @@
+import type { AssetStatus } from "@prisma/client";
+import { someKitMemberBlocksCustodyAssignment } from "./kits";
+
+/**
+ * Kit list rows exactly as the kits index loader supplies them.
+ *
+ * Membership arrives as `AssetKit` pivot rows — `assetKits[].asset` — and the
+ * rows reach the consumer through `selectedBulkItemsAtom`, which types every
+ * field as `any`. That makes these assertions the only check that the guard
+ * reads the field the loader actually sends.
+ *
+ * @see {@link file://./../routes/_layout+/kits._index.tsx}
+ */
+let nextKitId = 0;
+const kitRow = (...statuses: AssetStatus[]) => ({
+  id: `kit-${(nextKitId += 1)}`,
+  assetKits: statuses.map((status) => ({ asset: { status } })),
+});
+
+describe("someKitMemberBlocksCustodyAssignment", () => {
+  it("blocks when a member asset is checked out", () => {
+    expect(
+      someKitMemberBlocksCustodyAssignment([kitRow("AVAILABLE", "CHECKED_OUT")])
+    ).toBe(true);
+  });
+
+  it("blocks when a member asset is in custody", () => {
+    expect(
+      someKitMemberBlocksCustodyAssignment([kitRow("AVAILABLE", "IN_CUSTODY")])
+    ).toBe(true);
+  });
+
+  it("blocks when only one of several selected kits has a blocked member", () => {
+    expect(
+      someKitMemberBlocksCustodyAssignment([
+        kitRow("AVAILABLE"),
+        kitRow("AVAILABLE", "IN_CUSTODY"),
+      ])
+    ).toBe(true);
+  });
+
+  it("allows when every member asset is available", () => {
+    expect(
+      someKitMemberBlocksCustodyAssignment([
+        kitRow("AVAILABLE", "AVAILABLE"),
+        kitRow("AVAILABLE"),
+      ])
+    ).toBe(false);
+  });
+
+  it("allows an empty selection", () => {
+    expect(someKitMemberBlocksCustodyAssignment([])).toBe(false);
+  });
+
+  it("allows a kit with no members", () => {
+    expect(someKitMemberBlocksCustodyAssignment([kitRow()])).toBe(false);
+  });
+
+  it("allows rows the client never loaded, which the server re-validates", () => {
+    // "Select all across pages" selects rows with no membership payload. The
+    // guard is an affordance; `assetKits` being absent must not throw.
+    expect(
+      someKitMemberBlocksCustodyAssignment([{ id: "kit-unloaded" }])
+    ).toBe(false);
+  });
+});

--- a/apps/webapp/app/utils/kits.test.ts
+++ b/apps/webapp/app/utils/kits.test.ts
@@ -59,8 +59,8 @@ describe("someKitMemberBlocksCustodyAssignment", () => {
   it("allows rows the client never loaded, which the server re-validates", () => {
     // "Select all across pages" selects rows with no membership payload. The
     // guard is an affordance; `assetKits` being absent must not throw.
-    expect(
-      someKitMemberBlocksCustodyAssignment([{ id: "kit-unloaded" }])
-    ).toBe(false);
+    expect(someKitMemberBlocksCustodyAssignment([{ id: "kit-unloaded" }])).toBe(
+      false
+    );
   });
 });

--- a/apps/webapp/app/utils/kits.ts
+++ b/apps/webapp/app/utils/kits.ts
@@ -1,0 +1,59 @@
+import type { AssetStatus } from "@prisma/client";
+
+/**
+ * Pure helpers over kit list rows.
+ *
+ * These operate on rows as the kits index loader supplies them, where kit
+ * membership arrives as `AssetKit` pivot rows rather than a flat asset array.
+ * They live here rather than inline in a component because the rows reach the
+ * UI through `selectedBulkItemsAtom`, whose `ListItemData` is
+ * `{ id: string; [x: string]: any }` — an index signature that types every
+ * field access as `any`. Reading the payload through a declared parameter type
+ * is the only way the compiler can check these field names at all.
+ *
+ * @see {@link file://./../routes/_layout+/kits._index.tsx} — supplies `assetKits`
+ * @see {@link file://./../components/kits/bulk-actions-dropdown.tsx} — consumer
+ */
+
+/** Statuses that make a kit member ineligible for a custody assignment. */
+const CUSTODY_BLOCKING_ASSET_STATUSES: AssetStatus[] = [
+  "CHECKED_OUT",
+  "IN_CUSTODY",
+];
+
+/**
+ * A kit list row, narrowed to the membership the custody guard reads.
+ *
+ * `assetKits` is optional because "select all across pages" selects rows the
+ * client never loaded; see {@link someKitMemberBlocksCustodyAssignment}.
+ */
+export type KitRowWithMemberStatuses = {
+  id: string;
+  assetKits?: { asset: { status: AssetStatus } }[];
+};
+
+/**
+ * Whether any member asset of the given kits is checked out or in custody.
+ *
+ * Assigning custody of a kit assigns custody of its members, so a member that
+ * is already checked out or held by someone else has to be resolved first. The
+ * UI uses this to disable "Assign custody" with an explanation instead of
+ * letting the request fail server-side.
+ *
+ * A row with no `assetKits` contributes `false`. That is correct only because
+ * the server re-validates: under "select all", the client holds rows it never
+ * fetched, so this can only ever be an affordance, never the enforcement.
+ *
+ * @param kits - The selected kit rows, as the kits index loader supplies them
+ * @returns `true` if at least one member asset blocks a custody assignment
+ */
+export function someKitMemberBlocksCustodyAssignment(
+  kits: KitRowWithMemberStatuses[]
+): boolean {
+  return kits.some(
+    (kit) =>
+      kit.assetKits?.some((assetKit) =>
+        CUSTODY_BLOCKING_ASSET_STATUSES.includes(assetKit.asset.status)
+      )
+  );
+}

--- a/apps/webapp/app/utils/kits.ts
+++ b/apps/webapp/app/utils/kits.ts
@@ -1,5 +1,3 @@
-import type { AssetStatus } from "@prisma/client";
-
 /**
  * Pure helpers over kit list rows.
  *
@@ -14,6 +12,8 @@ import type { AssetStatus } from "@prisma/client";
  * @see {@link file://./../routes/_layout+/kits._index.tsx} — supplies `assetKits`
  * @see {@link file://./../components/kits/bulk-actions-dropdown.tsx} — consumer
  */
+
+import type { AssetStatus } from "@prisma/client";
 
 /** Statuses that make a kit member ineligible for a custody assignment. */
 const CUSTODY_BLOCKING_ASSET_STATUSES: AssetStatus[] = [

--- a/apps/webapp/test/routes-tests/api+/kits.test.tsx
+++ b/apps/webapp/test/routes-tests/api+/kits.test.tsx
@@ -89,9 +89,6 @@ const mockKits = [
         },
       },
     ],
-    _count: {
-      assetKits: 2,
-    },
   },
   {
     id: "kit-2",
@@ -113,29 +110,29 @@ const mockKits = [
         },
       },
     ],
-    _count: {
-      assetKits: 1,
-    },
   },
 ];
 
 /**
- * The shape `/api/kits` returns: each member asset goes through
- * `serializeAssetImage`, which drops the nested `assetModel` and emits the
- * resolved image fields plus `imageSource`. These mocks each carry their own
- * `mainImage` and no thumbnail, so the thumbnail falls back to the full-size
- * URL within the "asset" tier.
+ * The shape `/api/kits` returns.
+ *
+ * The `AssetKit` pivot is flattened away into a plain `assets` array — that is
+ * the contract `KitsListComponent` reads, and `useApiQuery` casts the response
+ * to the component's type without validating it, so nothing but this assertion
+ * stands between a renamed field and a crash on the booking activity page.
+ * Each member asset also goes through `serializeAssetImage`, which drops the
+ * nested `assetModel` and emits the resolved image fields plus `imageSource`.
+ * These mocks each carry their own `mainImage` and no thumbnail, so the
+ * thumbnail falls back to the full-size URL within the "asset" tier.
  */
-const serializedMockKits = mockKits.map((kit) => ({
+const serializedMockKits = mockKits.map(({ assetKits, ...kit }) => ({
   ...kit,
-  assetKits: kit.assetKits.map(({ asset }) => {
+  assets: assetKits.map(({ asset }) => {
     const { assetModel: _assetModel, ...rest } = asset;
     return {
-      asset: {
-        ...rest,
-        thumbnailImage: rest.mainImage,
-        imageSource: "asset",
-      },
+      ...rest,
+      thumbnailImage: rest.mainImage,
+      imageSource: "asset",
     };
   }),
 }));
@@ -202,11 +199,6 @@ describe("/api/kits", () => {
               },
             },
             orderBy: { asset: { title: "asc" } },
-          },
-          _count: {
-            select: {
-              assetKits: true,
-            },
           },
         },
         orderBy: {
@@ -314,11 +306,6 @@ describe("/api/kits", () => {
             },
             orderBy: { asset: { title: "asc" } },
           },
-          _count: {
-            select: {
-              assetKits: true,
-            },
-          },
         },
         orderBy: {
           name: "asc",
@@ -373,11 +360,6 @@ describe("/api/kits", () => {
               },
             },
             orderBy: { asset: { title: "asc" } },
-          },
-          _count: {
-            select: {
-              assetKits: true,
-            },
           },
         },
         orderBy: {
@@ -438,11 +420,6 @@ describe("/api/kits", () => {
               },
             },
             orderBy: { asset: { title: "asc" } },
-          },
-          _count: {
-            select: {
-              assetKits: true,
-            },
           },
         },
         orderBy: {
@@ -566,7 +543,6 @@ describe("/api/kits", () => {
             image: true,
             imageExpiration: true,
             assetKits: expect.any(Object),
-            _count: expect.any(Object),
           },
         })
       );


### PR DESCRIPTION
## The symptom

The booking activity page crashed into its full-page error boundary when a note
referencing **more than one kit** rendered its kits popover. The whole activity feed
went blank, not just the popover.

## Root cause

`266425e39` (*replace `Asset.kitId` with an `AssetKit` pivot*) changed what `/api/kits`
returns but never updated its only consumer, `KitsListComponent`.

| | Pre-pivot | Post-pivot | `KitsListComponent` reads |
| --- | --- | --- | --- |
| members | `assets: Asset[]` | `assetKits: [{ asset }]` | `kit.assets` ❌ |
| count | `_count.assets` | `_count.assetKits` | `_count.assets` ❌ (unread) |

So `kit.assets` was `undefined` and `kit.assets.length` threw inside `data.kits.map(...)`.

The popover does not have to be open to crash. Radix evaluates `PopoverContent`'s
children during `KitsListComponent`'s own render — it only decides *mounting* later — so
the throw escapes to the route `ErrorBoundary` and takes the entire page with it.

### Why nothing caught it

- `useApiQuery<TData>` casts `response.json()` to its type parameter with **no runtime
  validation**. The declared `Kit` type is a claim, not a contract, so tsc cannot compare
  producer against consumer. Same class as the existing `raw-sql-respects-prisma-map` rule.
- The route test asserted the shape the route *emitted* rather than the shape its consumer
  *needs* — it locked the broken payload in and went green.

## The fix

Flatten the pivot at the API boundary. `/api/kits` exists solely for this component, so
the pivot is a persistence detail the view should not carry. This also restores the
pre-pivot wire contract.

Also drops `_count: { select: { assetKits: true } }` from the Prisma select — nothing read
it, and since the route returns every pivot row (no `take`), `assets.length` is already
exact. One fewer `COUNT` per kit per popover.

**No `?? []` guard**, deliberately. That would mask a future drift behind a silently wrong
"(0 assets)". The contract is the fix; the tests are the guard.

## Tests

- `test/routes-tests/api+/kits.test.tsx` re-pointed at the corrected contract. Verified it
  **fails against the old payload** (5 failures) — this is the regression guard.
- `app/components/markdown/kits-list-component.test.tsx` is **new**: the popover had no
  coverage at all. It pins the consumer's side of the contract.

Both fixtures are derived from the route's real payload, so a future rename fails a test
instead of a page.

## Verification

- `tsc -b --force` → 0 errors
- ESLint on all changed files → 0 errors
- 129 tests green across `app/components/markdown`, `markdoc.config`, `markdoc-wrappers`
  and the `/api/kits` route test

## Follow-ups in this PR

Tracked separately in the commits that follow: a second instance of the same drift in
`kits/bulk-actions-dropdown.tsx` (where `?.` turns it into a permanently-false custody
guard rather than a crash), and a `.claude/rules/` entry for the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Kit listings now display member assets, asset counts, and image details consistently.
  - Kit asset data is presented in a simpler, more consistent format while preserving image handling.
  - Custody assignment is blocked when a selected kit contains an asset that is checked out or already in custody.

- **Tests**
  - Added coverage for kit counts, asset listings, asset totals, individual kit links, loading kits before opening details, and custody-assignment eligibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->