### PR TITLE
fix(bookings): judge a returned slice against its latest departure

### DIFF
--- a/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
@@ -758,6 +758,7 @@ describe("partialCheckoutBooking", () => {
       data: {
         bookingId: "booking-1",
         checkedOutById: "user-1",
+        checkoutTimestamp: expect.any(Date),
         assetIds: ["asset-1"],
         quantities: [1],
         bookingAssetIds: [""],
@@ -765,6 +766,92 @@ describe("partialCheckoutBooking", () => {
       },
     });
     expect(result.isComplete).toBe(true);
+  });
+
+  it("dates the delegated session row from the submission, never from the row write", async () => {
+    expect.assertions(3);
+
+    // The delegated row is written only after `checkoutBooking` has committed
+    // and its post-commit side effects have run. The completion gate reads the
+    // later of a session's timestamp and the slice marker as the departure a
+    // check-in has to answer, so the row has to be dated no later than the
+    // marker it accompanies.
+    const submittedAt = new Date();
+    // why: `Date` is faked so the clock can be moved inside the checkout
+    // transaction and again in the post-commit side effects; a row dated at
+    // its own write would then land after both.
+    vitest.useFakeTimers({ toFake: ["Date"] });
+    vitest.setSystemTime(submittedAt);
+    try {
+      // why: one asset covers everything outstanding, which is what sends the
+      // batch down the delegated full-checkout path.
+      const singleAssetBooking = {
+        ...reservedBooking,
+        _count: { bookingAssets: 1 },
+        bookingAssets: [
+          {
+            asset: {
+              id: "asset-1",
+              status: AssetStatus.AVAILABLE,
+              assetKits: [],
+            },
+          },
+        ],
+      };
+      let checkoutStarted = false;
+      // why: the marker's `checkedOutAt` is stamped inside the checkout
+      // transaction; moving the clock on entry puts the marker after the
+      // submission. Restored in `finally`.
+      (db.$transaction as ReturnType<typeof vitest.fn>).mockImplementation(
+        (callback: (tx: unknown) => unknown) => {
+          checkoutStarted = true;
+          vitest.setSystemTime(new Date(submittedAt.getTime() + 5_000));
+          return callback(db);
+        }
+      );
+      // why: the booking is read before the checkout and again to hydrate the
+      // return payload after its post-commit side effects; moving the clock on
+      // the reads that follow the transaction puts the row write after the
+      // marker. Restored in `finally`.
+      (
+        db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+      ).mockImplementation(() => {
+        if (checkoutStarted) {
+          vitest.setSystemTime(new Date(submittedAt.getTime() + 10_000));
+        }
+        return Promise.resolve(singleAssetBooking);
+      });
+
+      await partialCheckoutBooking({ ...baseParams, assetIds: ["asset-1"] });
+
+      const markerAt = (
+        db.bookingAsset.updateMany as ReturnType<typeof vitest.fn>
+      ).mock.calls
+        .map(([args]) => args?.data?.checkedOutAt)
+        .find((value): value is Date => value instanceof Date);
+      const sessionAt = (
+        db.partialBookingCheckout.create as ReturnType<typeof vitest.fn>
+      ).mock.calls
+        .map(([args]) => args?.data?.checkoutTimestamp)
+        .find((value): value is Date => value instanceof Date);
+
+      expect(sessionAt?.getTime()).toBe(submittedAt.getTime());
+      expect(sessionAt!.getTime()).toBeLessThanOrEqual(markerAt!.getTime());
+      // The clock has moved past both writes; a row dated at its own write
+      // would read as now.
+      expect(sessionAt!.getTime()).toBeLessThan(Date.now());
+    } finally {
+      vitest.useRealTimers();
+      (db.$transaction as ReturnType<typeof vitest.fn>).mockImplementation(
+        (callbackOrArray: unknown) =>
+          typeof callbackOrArray === "function"
+            ? (callbackOrArray as (tx: unknown) => unknown)(db)
+            : Promise.all(callbackOrArray as Promise<unknown>[])
+      );
+      (
+        db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+      ).mockResolvedValue({});
+    }
   });
 
   it("does NOT delegate to full checkout once partial-checkout records exist; the later final batch completes in the partial path", async () => {

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -10174,12 +10174,12 @@ describe("isBookingFullyCheckedIn", () => {
   it("does not let a first-trip check-in session reconcile a scan re-dispatch that kept the first marker", async () => {
     expect.assertions(1);
 
-    // A progressive check-out keeps a slice's original `checkedOutAt` ("out
-    // since" is the first departure). A slice that went out by scan, came back
-    // by scan and went out by scan again therefore carries the FIRST trip's
-    // marker, while its second departure is recorded only as a check-out
-    // session. The first trip's check-in session postdates that marker, and
-    // it must not stand in for a return that has not happened.
+    // why: a progressive check-out keeps a slice's original `checkedOutAt`
+    // ("out since" is the first departure). A slice that went out by scan,
+    // came back by scan and went out by scan again therefore carries the
+    // FIRST trip's marker, while its second departure is recorded only as a
+    // check-out session. The first trip's check-in session postdates that
+    // marker, and it must not stand in for a return that has not happened.
     //@ts-expect-error missing vitest type
     db.bookingAsset.findMany.mockResolvedValue([
       {
@@ -10195,7 +10195,8 @@ describe("isBookingFullyCheckedIn", () => {
         asset: { id: "asset-1", type: AssetType.INDIVIDUAL },
       },
     ]);
-    // Out at 10:00 and again at 14:00.
+    // why: out at 10:00 and again at 14:00. The second departure exists only
+    // as a check-out session; the marker alone reads as one trip.
     //@ts-expect-error missing vitest type
     db.partialBookingCheckout.findMany.mockResolvedValue([
       {
@@ -10211,7 +10212,8 @@ describe("isBookingFullyCheckedIn", () => {
         checkoutTimestamp: new Date("2026-01-01T14:00:00.000Z"),
       },
     ]);
-    // Back at 12:00, between the two departures.
+    // why: back at 12:00, between the two departures. The session answers
+    // the first trip only.
     //@ts-expect-error missing vitest type
     db.partialBookingCheckin.findMany.mockResolvedValue([
       {
@@ -10233,6 +10235,8 @@ describe("isBookingFullyCheckedIn", () => {
     // refusing every session on a re-dispatched slice. The slice went out
     // twice by scan and came back twice; the marker still shows the first
     // trip, and the latest check-in session postdates the latest departure.
+    // why: the marker still shows the first trip, so the sessions below decide
+    // the answer.
     //@ts-expect-error missing vitest type
     db.bookingAsset.findMany.mockResolvedValue([
       {
@@ -10246,6 +10250,7 @@ describe("isBookingFullyCheckedIn", () => {
         asset: { id: "asset-1", type: AssetType.INDIVIDUAL },
       },
     ]);
+    // why: out at 10:00 and again at 14:00, recorded only as sessions.
     //@ts-expect-error missing vitest type
     db.partialBookingCheckout.findMany.mockResolvedValue([
       {
@@ -10261,7 +10266,8 @@ describe("isBookingFullyCheckedIn", () => {
         checkoutTimestamp: new Date("2026-01-01T14:00:00.000Z"),
       },
     ]);
-    // Back at 12:00 and again at 16:00, after the second departure.
+    // why: back at 12:00 and again at 16:00. The 16:00 session postdates the
+    // latest departure, so it answers it.
     //@ts-expect-error missing vitest type
     db.partialBookingCheckin.findMany.mockResolvedValue([
       {
@@ -10282,9 +10288,9 @@ describe("isBookingFullyCheckedIn", () => {
   it("does not let first-trip markers reconcile a later scan departure", async () => {
     expect.assertions(1);
 
-    // Both markers can predate the latest departure: rows stamped from session
-    // history carry each side's EARLIEST session, so a slice that was out,
-    // back and out again by scan reads as one complete round trip on its
+    // why: both markers can predate the latest departure. Rows stamped from
+    // session history carry each side's EARLIEST session, so a slice that was
+    // out, back and out again by scan reads as one complete round trip on its
     // markers alone. The check-out sessions still record the second departure,
     // and no check-in answers it.
     //@ts-expect-error missing vitest type
@@ -10300,6 +10306,8 @@ describe("isBookingFullyCheckedIn", () => {
         asset: { id: "asset-1", type: AssetType.INDIVIDUAL },
       },
     ]);
+    // why: the 14:00 departure is recorded only here; the markers do not
+    // show it.
     //@ts-expect-error missing vitest type
     db.partialBookingCheckout.findMany.mockResolvedValue([
       {
@@ -10315,6 +10323,8 @@ describe("isBookingFullyCheckedIn", () => {
         checkoutTimestamp: new Date("2026-01-01T14:00:00.000Z"),
       },
     ]);
+    // why: the only return answers the first trip; nothing answers the 14:00
+    // departure.
     //@ts-expect-error missing vitest type
     db.partialBookingCheckin.findMany.mockResolvedValue([
       {

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -10171,6 +10171,163 @@ describe("isBookingFullyCheckedIn", () => {
     expect(result).toBe(true);
   });
 
+  it("does not let a first-trip check-in session reconcile a scan re-dispatch that kept the first marker", async () => {
+    expect.assertions(1);
+
+    // A progressive check-out keeps a slice's original `checkedOutAt` ("out
+    // since" is the first departure). A slice that went out by scan, came back
+    // by scan and went out by scan again therefore carries the FIRST trip's
+    // marker, while its second departure is recorded only as a check-out
+    // session. The first trip's check-in session postdates that marker, and
+    // it must not stand in for a return that has not happened.
+    //@ts-expect-error missing vitest type
+    db.bookingAsset.findMany.mockResolvedValue([
+      {
+        id: "ba-1",
+        assetId: "asset-1",
+        quantity: 1,
+        assetKitId: null,
+        // First departure; the second one did not refresh it.
+        checkedOutAt: new Date("2026-01-01T10:00:00.000Z"),
+        // Cleared by the second departure.
+        checkedInAt: null,
+        checkedOutQuantity: 2,
+        asset: { id: "asset-1", type: AssetType.INDIVIDUAL },
+      },
+    ]);
+    // Out at 10:00 and again at 14:00.
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckout.findMany.mockResolvedValue([
+      {
+        assetIds: ["asset-1"],
+        quantities: [1],
+        bookingAssetIds: [""],
+        checkoutTimestamp: new Date("2026-01-01T10:00:00.000Z"),
+      },
+      {
+        assetIds: ["asset-1"],
+        quantities: [1],
+        bookingAssetIds: [""],
+        checkoutTimestamp: new Date("2026-01-01T14:00:00.000Z"),
+      },
+    ]);
+    // Back at 12:00, between the two departures.
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckin.findMany.mockResolvedValue([
+      {
+        assetIds: ["asset-1"],
+        checkinTimestamp: new Date("2026-01-01T12:00:00.000Z"),
+      },
+    ]);
+
+    const result = await isBookingFullyCheckedIn(db, "booking-1");
+
+    // The asset is out on its second trip.
+    expect(result).toBe(false);
+  });
+
+  it("accepts a check-in session that answers the latest scan departure", async () => {
+    expect.assertions(1);
+
+    // The mirror of the case above, so the guard cannot be satisfied by
+    // refusing every session on a re-dispatched slice. The slice went out
+    // twice by scan and came back twice; the marker still shows the first
+    // trip, and the latest check-in session postdates the latest departure.
+    //@ts-expect-error missing vitest type
+    db.bookingAsset.findMany.mockResolvedValue([
+      {
+        id: "ba-1",
+        assetId: "asset-1",
+        quantity: 1,
+        assetKitId: null,
+        checkedOutAt: new Date("2026-01-01T10:00:00.000Z"),
+        checkedInAt: null,
+        checkedOutQuantity: 2,
+        asset: { id: "asset-1", type: AssetType.INDIVIDUAL },
+      },
+    ]);
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckout.findMany.mockResolvedValue([
+      {
+        assetIds: ["asset-1"],
+        quantities: [1],
+        bookingAssetIds: [""],
+        checkoutTimestamp: new Date("2026-01-01T10:00:00.000Z"),
+      },
+      {
+        assetIds: ["asset-1"],
+        quantities: [1],
+        bookingAssetIds: [""],
+        checkoutTimestamp: new Date("2026-01-01T14:00:00.000Z"),
+      },
+    ]);
+    // Back at 12:00 and again at 16:00, after the second departure.
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckin.findMany.mockResolvedValue([
+      {
+        assetIds: ["asset-1"],
+        checkinTimestamp: new Date("2026-01-01T12:00:00.000Z"),
+      },
+      {
+        assetIds: ["asset-1"],
+        checkinTimestamp: new Date("2026-01-01T16:00:00.000Z"),
+      },
+    ]);
+
+    const result = await isBookingFullyCheckedIn(db, "booking-1");
+
+    expect(result).toBe(true);
+  });
+
+  it("does not let first-trip markers reconcile a later scan departure", async () => {
+    expect.assertions(1);
+
+    // Both markers can predate the latest departure: rows stamped from session
+    // history carry each side's EARLIEST session, so a slice that was out,
+    // back and out again by scan reads as one complete round trip on its
+    // markers alone. The check-out sessions still record the second departure,
+    // and no check-in answers it.
+    //@ts-expect-error missing vitest type
+    db.bookingAsset.findMany.mockResolvedValue([
+      {
+        id: "ba-1",
+        assetId: "asset-1",
+        quantity: 1,
+        assetKitId: null,
+        checkedOutAt: new Date("2026-01-01T10:00:00.000Z"),
+        checkedInAt: new Date("2026-01-01T12:00:00.000Z"),
+        checkedOutQuantity: 2,
+        asset: { id: "asset-1", type: AssetType.INDIVIDUAL },
+      },
+    ]);
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckout.findMany.mockResolvedValue([
+      {
+        assetIds: ["asset-1"],
+        quantities: [1],
+        bookingAssetIds: [""],
+        checkoutTimestamp: new Date("2026-01-01T10:00:00.000Z"),
+      },
+      {
+        assetIds: ["asset-1"],
+        quantities: [1],
+        bookingAssetIds: [""],
+        checkoutTimestamp: new Date("2026-01-01T14:00:00.000Z"),
+      },
+    ]);
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckin.findMany.mockResolvedValue([
+      {
+        assetIds: ["asset-1"],
+        checkinTimestamp: new Date("2026-01-01T12:00:00.000Z"),
+      },
+    ]);
+
+    const result = await isBookingFullyCheckedIn(db, "booking-1");
+
+    expect(result).toBe(false);
+  });
+
   it("returns false when qty-tracked units went out, came back, and went out again", async () => {
     expect.assertions(1);
 

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -4516,6 +4516,25 @@ export async function computeBookingAssetsSliceRemainingToCheckOut(
 }
 
 /**
+ * Latest session timestamp per asset id, over progressive session rows that
+ * name the asset. A row without a timestamp dates nothing and is skipped.
+ */
+function latestSessionTimestampByAsset(
+  rows: Array<{ assetIds: string[]; at: Date | null }>
+): Map<string, Date> {
+  const latestByAsset = new Map<string, Date>();
+  for (const row of rows) {
+    const at = row.at;
+    if (!at) continue;
+    for (const id of row.assetIds) {
+      const seen = latestByAsset.get(id);
+      if (!seen || at > seen) latestByAsset.set(id, at);
+    }
+  }
+  return latestByAsset;
+}
+
+/**
  * Determines whether a booking has been fully checked in across all of
  * its assets.
  *
@@ -4531,8 +4550,13 @@ export async function computeBookingAssetsSliceRemainingToCheckOut(
  * For `INDIVIDUAL` assets: a slice with `checkedOutAt` must be reconciled —
  * `checkedInAt` set, or present in a `PartialBookingCheckin.assetIds` row
  * (rows reconciled before the marker existed carry only the session record).
- * Slices never dispatched (added onto an ONGOING booking, or left behind by
- * a progressive checkout) have nothing to check in and never block.
+ * The reconciliation has to be no older than the slice's latest departure,
+ * which is the later of its marker and the newest `PartialBookingCheckout`
+ * session naming the asset: the marker dates the first departure, and a
+ * check-in that answered an earlier trip stays on record after the slice
+ * goes out again. Slices never dispatched (added onto an ONGOING booking, or
+ * left behind by a progressive checkout) have nothing to check in and never
+ * block.
  *
  * For `QUANTITY_TRACKED` assets: obligated units are judged PER SLICE and
  * summed — a slice's session-attributed units when any exist (capped by its
@@ -4543,9 +4567,10 @@ export async function computeBookingAssetsSliceRemainingToCheckOut(
  * unit is reconciled; units that never left the warehouse carry no
  * obligation.
  *
- * Called by both `partialCheckinBooking` and `checkinBooking` to decide
- * the ONGOING/OVERDUE → COMPLETE transition. Keeping this in one place
- * prevents the two code paths from drifting.
+ * Called by `partialCheckinBooking` to decide the ONGOING/OVERDUE →
+ * COMPLETE transition. The all-at-once `checkinBooking` returns every
+ * outstanding slice and completes unconditionally, so this is the one place
+ * that judges completion.
  *
  * @param tx - Prisma transaction client
  * @param bookingId - Booking to evaluate
@@ -4589,7 +4614,15 @@ export async function isBookingFullyCheckedIn(
     }),
     tx.partialBookingCheckout.findMany({
       where: { bookingId },
-      select: { assetIds: true, quantities: true, bookingAssetIds: true },
+      // The timestamp records a departure the slice marker cannot: a
+      // progressive check-out keeps a slice's first `checkedOutAt`, so a
+      // later departure of the same asset is dated here and nowhere else.
+      select: {
+        assetIds: true,
+        quantities: true,
+        bookingAssetIds: true,
+        checkoutTimestamp: true,
+      },
     }),
   ]);
 
@@ -4604,18 +4637,29 @@ export async function isBookingFullyCheckedIn(
    * whose asset id never leaves this set, and a bare set of ids would let that
    * session reconcile the second departure too.
    */
-  const latestSessionCheckinByAsset = new Map<string, Date>();
-  for (const row of partialCheckins as Array<{
-    assetIds: string[];
-    checkinTimestamp: Date | null;
-  }>) {
-    for (const id of row.assetIds) {
-      const at = row.checkinTimestamp;
-      if (!at) continue;
-      const seen = latestSessionCheckinByAsset.get(id);
-      if (!seen || at > seen) latestSessionCheckinByAsset.set(id, at);
-    }
-  }
+  const latestSessionCheckinByAsset = latestSessionTimestampByAsset(
+    (
+      partialCheckins as Array<{
+        assetIds: string[];
+        checkinTimestamp: Date | null;
+      }>
+    ).map((row) => ({ assetIds: row.assetIds, at: row.checkinTimestamp }))
+  );
+
+  /**
+   * The most recent check-out session naming each asset. The slice marker
+   * dates the FIRST departure only — a progressive re-dispatch clears
+   * `checkedInAt` and keeps `checkedOutAt`, which is what "out since" shows —
+   * so a slice's latest departure is the later of its marker and this.
+   */
+  const latestSessionCheckoutByAsset = latestSessionTimestampByAsset(
+    (
+      partialCheckouts as Array<{
+        assetIds: string[];
+        checkoutTimestamp: Date | null;
+      }>
+    ).map((row) => ({ assetIds: row.assetIds, at: row.checkoutTimestamp }))
+  );
 
   type SliceRow = {
     id: string;
@@ -4673,21 +4717,24 @@ export async function isBookingFullyCheckedIn(
       // onto an ONGOING booking, or left behind by a progressive checkout)
       // has nothing to reconcile and never blocks.
       if (!ba.checkedOutAt) continue;
-      // Reconciled — by the slice marker, or by a partial-checkin session
-      // for rows reconciled before the marker existed.
-      //
-      // The check-in has to be no older than the departure it answers. A slice
-      // that came back and then went out again carries both markers, and the
-      // refreshed `checkedOutAt` is what says it is out now; reading
-      // `checkedInAt` alone would report the second trip as already returned.
-      if (ba.checkedInAt && ba.checkedInAt >= ba.checkedOutAt) continue;
-      // Session fallback, for rows reconciled before the marker existed. It is
-      // held to the same test as the marker: the session has to be no older
-      // than the departure it claims to answer. Without that, a second
-      // departure clears `checkedInAt` and the FIRST trip's session — whose
-      // asset id is still listed — silently reconciles the new one.
-      const sessionAt = latestSessionCheckinByAsset.get(ba.assetId);
-      if (sessionAt && sessionAt >= ba.checkedOutAt) continue;
+      // The latest departure a return has to answer: the marker, or a newer
+      // check-out session naming the asset. The all-at-once checkout refreshes
+      // the marker when a reconciled slice goes out again; the progressive
+      // checkout keeps the first one, so its later departures are dated only
+      // by their session.
+      const sessionOutAt = latestSessionCheckoutByAsset.get(ba.assetId);
+      const departedAt =
+        sessionOutAt && sessionOutAt > ba.checkedOutAt
+          ? sessionOutAt
+          : ba.checkedOutAt;
+      // Reconciled — by the slice marker, or by a check-in session for rows
+      // reconciled before the marker existed. Either has to be no older than
+      // that departure: a check-in that answered an earlier trip stays on
+      // record after the slice goes out again, and read against the first
+      // departure it would report the new trip as already returned.
+      if (ba.checkedInAt && ba.checkedInAt >= departedAt) continue;
+      const sessionInAt = latestSessionCheckinByAsset.get(ba.assetId);
+      if (sessionInAt && sessionInAt >= departedAt) continue;
       return false;
     }
 

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -4711,11 +4711,19 @@ export async function isBookingFullyCheckedIn(
     const isQtyTrackedAsset = ba.asset?.type === AssetType.QUANTITY_TRACKED;
 
     if (!isQtyTrackedAsset) {
-      // INDIVIDUAL. The slice marker is the same source the check-in
-      // eligibility guard reads, so an asset gates completion exactly when
-      // it is checkinable. A slice never dispatched on THIS booking (added
-      // onto an ONGOING booking, or left behind by a progressive checkout)
-      // has nothing to reconcile and never blocks.
+      // INDIVIDUAL. Dispatch is read from the slice marker, the same source
+      // the scan check-in guard reads, so a slice never dispatched on THIS
+      // booking (added onto an ONGOING booking, or left behind by a
+      // progressive checkout) has nothing to reconcile and never blocks.
+      //
+      // Reconciliation is judged against the slice's latest departure below,
+      // while the scan check-in guard reads `checkedInAt` alone. Both
+      // check-out writers clear `checkedInAt` on a re-dispatch, so the two
+      // agree on every slice they produce. They part on a slice whose markers
+      // were stamped from each side's earliest session and which a later scan
+      // departure sent out again: this gate holds the booking, the scan flow
+      // refuses the slice as already checked in, and the all-at-once check-in
+      // is the path that closes the booking.
       if (!ba.checkedOutAt) continue;
       // The latest departure a return has to answer: the marker, or a newer
       // check-out session naming the asset. The all-at-once checkout refreshes

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -8046,6 +8046,12 @@ export async function partialCheckoutBooking({
       qtyClaimsCoverFullRemaining;
 
     if (shouldDelegateToFullCheckout) {
+      // The departure this session records. A session dates the departure it
+      // describes, never a later instant: the completion gate reads the later
+      // of a session's timestamp and the slice marker as the departure a
+      // check-in has to answer, and the row below is written only after the
+      // checkout has committed and its side effects have run.
+      const departedAt = new Date();
       const fullyCheckedOut = await checkoutBooking({
         id,
         organizationId,
@@ -8094,6 +8100,9 @@ export async function partialCheckoutBooking({
           data: {
             bookingId: id,
             checkedOutById: userId,
+            // Dated from the capture above, not from the row's own default, so
+            // the session never postdates the marker it accompanies.
+            checkoutTimestamp: departedAt,
             assetIds: outstandingAssetIds,
             quantities: outstandingQuantities,
             bookingAssetIds: outstandingBookingAssetIds,


### PR DESCRIPTION
## Summary

`isBookingFullyCheckedIn` judges an `INDIVIDUAL` slice as returned when its check-in marker, or the latest `PartialBookingCheckin` session naming the asset, is no older than `BookingAsset.checkedOutAt`.

The two check-out writers disagree on what `checkedOutAt` means once a reconciled slice goes out again:

- `checkoutBookingWritesWithinTx` (the Check out button, also reached by the fulfil-and-checkout path) refreshes `checkedOutAt` and clears `checkedInAt`.
- `partialCheckoutBooking` (progressive scans) is first-marker-wins: it clears `checkedInAt` and keeps the original `checkedOutAt`, so "out since" stays the first departure.

On the progressive path the sequence out (T1) → in (T2) → out again (T3) leaves the slice with `checkedOutAt = T1`, `checkedInAt = null`, a check-in session at T2, and check-out sessions at T1 and T3. The marker test fails, the session fallback passes (`T2 >= T1`), and the slice counts as returned while it is physically out. The next progressive check-in of the remaining items then completes the booking with that slice out. A completed booking has no screen that can check anything in, so the slice stays stranded.

## Fix

The gate now computes a slice's latest departure as the later of its marker and the newest `PartialBookingCheckout` session naming the asset, and holds both the marker and the session fallback to it: a reconciliation counts only if it is no older than every recorded departure of that asset on the booking. `checkoutTimestamp` is added to the gate's session read. No writer changes, so the "out since" display semantics are untouched.

The floor is applied to the marker comparison as well, not only to the session fallback. Rows stamped by the marker backfill carry each side's EARLIEST session (`checkedOutAt` from the first check-out session, `checkedInAt` from the first check-in session), so a slice that was out, back and out again by scan before the markers existed reads as a complete round trip on its markers alone. With the floor, its second departure, still dated by its check-out session, blocks completion until a check-in answers it.

The button path is not changed. It refreshes `checkedOutAt` on re-dispatch, so it was already judged correctly.

`QUANTITY_TRACKED` slices are not affected: their obligation is unit arithmetic over the cumulative `checkedOutQuantity` counter and the reconciled `ConsumptionLog` units, with no timestamp comparison.

## Delegated first scan

The first all-items scan of a RESERVED booking delegates to the full checkout and writes its session row afterwards, once that checkout has committed and its post-commit side effects have run. With the gate now reading the newest check-out session as a departure, a row dated at its own write could postdate a check-in that landed in that window and hold the slice open for the gate. The departure instant is captured before delegating and written as that row's `checkoutTimestamp`, so a session never postdates the marker it accompanies. The other two session writers create their row inside the same transaction as the marker write and are unaffected; the partial-checkout history is the only other reader of that timestamp, and this row is the booking's first session by construction.

## Tests

Three cases added to the `isBookingFullyCheckedIn` block in `service.server.test.ts`. The first and third fail on `main` (the gate returns `true`):

- the exact sequence above, first marker kept, check-in session between the two departures → `false`
- the mirror: a second check-in session after the second departure → `true` (the guard cannot be satisfied by refusing every session on a re-dispatched slice)
- backfilled-marker shape: both markers date the first trip, a later check-out session, no later check-in → `false`

One case added to `service.server.partial-checkout.test.ts`: the delegated first scan dates its session row from the submission, with a fake clock moved inside the checkout transaction and on the post-commit hydrate read. It fails on `main` (the row carries no explicit timestamp).

`pnpm webapp:test -- --run app/modules/booking/service.server.test.ts` (331 passed), `pnpm webapp:test -- --run app/modules/booking/service.server.partial-checkout.test.ts` (63 passed), `pnpm webapp:lint` (0 errors), and `pnpm --filter @shelf/webapp typecheck` pass.

## Deploy

No migration. Server-only change to the completion gate.

## Known limitation

The gate and the scan check-in guard read dispatch from the same slice marker but judge reconciliation differently: the gate against the slice's latest departure (this PR), the guard in `partialCheckinBooking` against `checkedInAt` alone. They agree on every slice the runtime writers produce, because both check-out writers clear `checkedInAt` on re-dispatch. They part on a slice whose markers were stamped by the 2026-08-27 backfill from each side's earliest session and which a later scan departure sent out again: the gate now holds the booking open (third test), but the scan check-in refuses that slice as already checked in, so the all-at-once Check in button is the path that closes such a booking. Aligning the guard also touches the drawer eligibility in the routes and is left for a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved booking check-in completion for individual bookings with multiple trips.
  - Check-in status now evaluates the latest departure, preventing an earlier check-in from incorrectly completing a later trip.
  - Bookings remain incomplete until the return from the most recent trip is recorded.
  - Check-in sessions are matched against the latest scan departure for accurate completion status.
  - Session timing now reflects when the departure was submitted.
  - Added coverage for repeated departures and check-in sessions to ensure completion status is reported accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->