### PR TITLE
fix(onboarding): keep the role and team-size fields answerable without JS

### DIFF
--- a/apps/webapp/app/components/forms/select-with-other.test.tsx
+++ b/apps/webapp/app/components/forms/select-with-other.test.tsx
@@ -138,6 +138,37 @@ describe("SelectWithOther during the hydration swap", () => {
     container.remove();
   });
 
+  it("keeps a field the user cleared before hydration cleared", () => {
+    const field = (
+      <SelectWithOther
+        label="What's your role?"
+        name="jobTitle"
+        options={OPTIONS}
+        defaultValue="Operations Manager"
+        otherInputLabel="Specify your role"
+      />
+    );
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    container.innerHTML = renderToString(field);
+
+    // The user clears the saved answer while the bundle is still loading.
+    container.querySelector("select")!.value = "";
+
+    let root: ReturnType<typeof hydrateRoot>;
+    act(() => {
+      root = hydrateRoot(container, field);
+    });
+
+    expect(
+      container.querySelector<HTMLInputElement>('input[name="jobTitle"]')?.value
+    ).toBe("");
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
   it("falls back to the saved value when the user answered nothing", () => {
     const field = (
       <SelectWithOther

--- a/apps/webapp/app/components/forms/select-with-other.test.tsx
+++ b/apps/webapp/app/components/forms/select-with-other.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * SelectWithOther — unit tests
+ *
+ * The onboarding form's required answers are captured by this control, so the
+ * field has to stay answerable even when the page's JavaScript never runs.
+ * These tests cover both halves of that contract:
+ *  - the server render is a native <select> carrying the field's `name`
+ *  - once hydrated, the styled popover takes over and writes the chosen value
+ *
+ * @see {@link file://./select-with-other.tsx}
+ */
+
+import { render } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { SelectWithOther } from "./select-with-other";
+
+const OPTIONS = ["Operations Manager", "IT Administrator"] as const;
+
+function renderOnServer(defaultValue?: string) {
+  return renderToStaticMarkup(
+    <SelectWithOther
+      label="What's your role?"
+      name="jobTitle"
+      options={OPTIONS}
+      required
+      defaultValue={defaultValue}
+      otherInputLabel="Specify your role"
+    />
+  );
+}
+
+describe("SelectWithOther without JavaScript", () => {
+  it("server-renders a native select that carries the field name", () => {
+    const html = renderOnServer();
+
+    expect(html).toContain('<select id="jobTitle" name="jobTitle" required=""');
+    // A hidden input would submit an empty answer and dead-end the form.
+    expect(html).not.toContain('type="hidden"');
+    // The popover trigger is inert without JS, so it must not be the server render.
+    expect(html).not.toContain('aria-haspopup="dialog"');
+  });
+
+  it("offers every option plus the free-text escape hatch", () => {
+    const html = renderOnServer();
+
+    for (const option of OPTIONS) {
+      expect(html).toContain(`<option value="${option}">${option}</option>`);
+    }
+    expect(html).toContain('<option value="Other">Other</option>');
+  });
+
+  it("preserves a previously saved free-text answer", () => {
+    const html = renderOnServer("Head Groundskeeper");
+
+    expect(html).toContain(
+      '<option value="Head Groundskeeper" selected="">Head Groundskeeper</option>'
+    );
+  });
+
+  it("preselects a saved preset answer", () => {
+    const html = renderOnServer("IT Administrator");
+
+    expect(html).toContain(
+      '<option value="IT Administrator" selected="">IT Administrator</option>'
+    );
+  });
+});
+
+describe("SelectWithOther once hydrated", () => {
+  it("swaps the native select for the styled control", () => {
+    const { container, getByRole } = render(
+      <SelectWithOther
+        label="What's your role?"
+        name="jobTitle"
+        options={OPTIONS}
+        required
+        otherInputLabel="Specify your role"
+      />
+    );
+
+    expect(container.querySelector("select")).toBeNull();
+    expect(getByRole("button", { name: "What's your role?" })).toBeTruthy();
+    // Exactly one control submits the value, whichever half is rendered.
+    expect(container.querySelectorAll('[name="jobTitle"]')).toHaveLength(1);
+  });
+
+  it("keeps a saved answer selected", () => {
+    const { container } = render(
+      <SelectWithOther
+        label="What's your role?"
+        name="jobTitle"
+        options={OPTIONS}
+        required
+        defaultValue="IT Administrator"
+        otherInputLabel="Specify your role"
+      />
+    );
+
+    expect(
+      container.querySelector<HTMLInputElement>('input[name="jobTitle"]')?.value
+    ).toBe("IT Administrator");
+  });
+});

--- a/apps/webapp/app/components/forms/select-with-other.test.tsx
+++ b/apps/webapp/app/components/forms/select-with-other.test.tsx
@@ -10,8 +10,9 @@
  * @see {@link file://./select-with-other.tsx}
  */
 
-import { render } from "@testing-library/react";
-import { renderToStaticMarkup } from "react-dom/server";
+import { act, render } from "@testing-library/react";
+import { hydrateRoot } from "react-dom/client";
+import { renderToStaticMarkup, renderToString } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { SelectWithOther } from "./select-with-other";
 
@@ -100,5 +101,69 @@ describe("SelectWithOther once hydrated", () => {
     expect(
       container.querySelector<HTMLInputElement>('input[name="jobTitle"]')?.value
     ).toBe("IT Administrator");
+  });
+});
+
+describe("SelectWithOther during the hydration swap", () => {
+  it("keeps an answer given before the bundle arrived", () => {
+    const field = (
+      <SelectWithOther
+        label="What's your role?"
+        name="jobTitle"
+        options={OPTIONS}
+        required
+        otherInputLabel="Specify your role"
+      />
+    );
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    container.innerHTML = renderToString(field);
+
+    // The user answers the server-rendered select while the bundle is loading.
+    const select = container.querySelector("select");
+    expect(select).not.toBeNull();
+    select!.value = "IT Administrator";
+
+    let root: ReturnType<typeof hydrateRoot>;
+    act(() => {
+      root = hydrateRoot(container, field);
+    });
+
+    expect(
+      container.querySelector<HTMLInputElement>('input[name="jobTitle"]')?.value
+    ).toBe("IT Administrator");
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("falls back to the saved value when the user answered nothing", () => {
+    const field = (
+      <SelectWithOther
+        label="What's your role?"
+        name="jobTitle"
+        options={OPTIONS}
+        required
+        defaultValue="Operations Manager"
+        otherInputLabel="Specify your role"
+      />
+    );
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    container.innerHTML = renderToString(field);
+
+    let root: ReturnType<typeof hydrateRoot>;
+    act(() => {
+      root = hydrateRoot(container, field);
+    });
+
+    expect(
+      container.querySelector<HTMLInputElement>('input[name="jobTitle"]')?.value
+    ).toBe("Operations Manager");
+
+    act(() => root.unmount());
+    container.remove();
   });
 });

--- a/apps/webapp/app/components/forms/select-with-other.tsx
+++ b/apps/webapp/app/components/forms/select-with-other.tsx
@@ -187,14 +187,21 @@ export function SelectWithOther(props: SelectWithOtherProps) {
    * it before the bundle arrives. React has not committed its removal yet while
    * this render runs, so read the live answer here: seeding the enhanced control
    * from `defaultValue` alone would silently throw that answer away and leave a
-   * required field empty. `EnhancedSelectWithOther` only reads `defaultValue`
-   * to seed its initial state, so it does not matter that the ref is empty on
-   * later renders.
+   * required field empty.
+   *
+   * The ref, not the value, decides which one wins. An empty live value means
+   * the user cleared the field on purpose and must stay cleared, while a missing
+   * ref means the fallback never rendered — a client-side navigation onto the
+   * form — and the saved answer is all there is. `EnhancedSelectWithOther` only
+   * reads `defaultValue` to seed its initial state, so it does not matter that
+   * the ref is empty again on later renders.
    */
+  const fallbackSelect = fallbackRef.current;
+
   return (
     <EnhancedSelectWithOther
       {...props}
-      defaultValue={fallbackRef.current?.value || props.defaultValue}
+      defaultValue={fallbackSelect ? fallbackSelect.value : props.defaultValue}
     />
   );
 }

--- a/apps/webapp/app/components/forms/select-with-other.tsx
+++ b/apps/webapp/app/components/forms/select-with-other.tsx
@@ -8,6 +8,7 @@ import {
   PopoverTrigger,
 } from "@radix-ui/react-popover";
 import { CheckIcon, ChevronDownIcon } from "lucide-react";
+import { useHydrated } from "remix-utils/use-hydrated";
 
 import Input from "~/components/forms/input";
 import When from "~/components/when/when";
@@ -16,6 +17,20 @@ import { resolveSelectState } from "~/utils/options";
 import { tw } from "~/utils/tw";
 
 export const OTHER_OPTION_VALUE = "other";
+
+/**
+ * Value submitted by the no-JavaScript fallback when the user picks "Other".
+ *
+ * It is a plain human-readable string rather than {@link OTHER_OPTION_VALUE} so
+ * that it is safe to persist as-is, and so that re-rendering the form with it as
+ * `defaultValue` puts the enhanced control into its "Other" state with "Other"
+ * as the custom text (see `resolveSelectState`).
+ */
+const OTHER_FALLBACK_VALUE = "Other";
+
+/** Classes shared by the enhanced trigger and the fallback <select>. */
+const CONTROL_CLASSES =
+  "h-[44px] w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-left text-gray-900 hover:border-gray-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary";
 
 type SelectWithOtherProps = {
   /** Accessible label for the select field. */
@@ -69,7 +84,103 @@ function FieldLabel({
   );
 }
 
-export function SelectWithOther({
+/**
+ * Server-rendered version of the control that works without JavaScript.
+ *
+ * The enhanced control is a Radix popover writing into a hidden input, so it is
+ * inert until React hydrates. Onboarding is the first screen of the product and
+ * these answers are required, so a browser that never hydrates (JavaScript
+ * blocked, a bundle that fails to parse, an extension breaking the page) would
+ * otherwise dead-end the signup with no way to answer. A native <select> carries
+ * the same `name`, submits with the plain form POST, and supports type-ahead and
+ * the browser's own required-field validation with no scripting at all.
+ */
+function UnhydratedSelectWithOther({
+  label,
+  name,
+  options,
+  error,
+  defaultValue,
+  placeholder = "Select an option",
+  required,
+  children,
+  className,
+}: SelectWithOtherProps) {
+  const { selection, customValue } = resolveSelectState(
+    options,
+    defaultValue ?? undefined
+  );
+
+  /**
+   * A previously stored free-text answer is not in `options`, so it needs its
+   * own <option> or the select would silently drop it on the next submit.
+   */
+  const preservedCustomValue =
+    selection === OTHER_OPTION_VALUE && customValue !== OTHER_FALLBACK_VALUE
+      ? customValue
+      : null;
+
+  const selectedValue =
+    selection === OTHER_OPTION_VALUE
+      ? preservedCustomValue ?? OTHER_FALLBACK_VALUE
+      : selection;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <FieldLabel htmlFor={name} required={required}>
+        {label}
+      </FieldLabel>
+      <select
+        id={name}
+        name={name}
+        required={required}
+        defaultValue={selectedValue}
+        className={tw(
+          CONTROL_CLASSES,
+          // Greys out the placeholder the way the enhanced trigger does: a
+          // required select with no answer is :invalid.
+          required && "invalid:text-gray-500",
+          error &&
+            "border-error-300 focus:border-error-300 focus:ring-error-100",
+          className
+        )}
+      >
+        <option value="">{placeholder}</option>
+        {options.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+        {preservedCustomValue ? (
+          <option value={preservedCustomValue}>{preservedCustomValue}</option>
+        ) : null}
+        <option value={OTHER_FALLBACK_VALUE}>{OTHER_FALLBACK_VALUE}</option>
+      </select>
+      {error ? <p className="text-sm text-error-500">{error}</p> : null}
+      {children}
+    </div>
+  );
+}
+
+/**
+ * A single-choice field with a free-text "Other" escape hatch.
+ *
+ * Renders a plain <select> on the server and swaps to the styled popover once
+ * React has hydrated, so the field is answerable even when the page's
+ * JavaScript never runs. Mirrors the `useHydrated` split used by the app's
+ * other dropdowns (see `components/kits/actions-dropdown.tsx`).
+ */
+export function SelectWithOther(props: SelectWithOtherProps) {
+  const isHydrated = useHydrated();
+
+  if (!isHydrated) {
+    return <UnhydratedSelectWithOther {...props} />;
+  }
+
+  return <EnhancedSelectWithOther {...props} />;
+}
+
+function EnhancedSelectWithOther({
   label,
   name,
   options,
@@ -181,7 +292,8 @@ export function SelectWithOther({
             type="button"
             tabIndex={0}
             className={tw(
-              "flex h-[44px] w-full items-center justify-between rounded-md border border-gray-300 bg-white px-3 py-2 text-left text-gray-900 hover:border-gray-400 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary",
+              "flex items-center justify-between",
+              CONTROL_CLASSES,
               !selection && "text-gray-500",
               error &&
                 "border-error-300 focus:border-error-300 focus:ring-error-100",

--- a/apps/webapp/app/components/forms/select-with-other.tsx
+++ b/apps/webapp/app/components/forms/select-with-other.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { KeyboardEvent, ReactNode } from "react";
+import type { KeyboardEvent, ReactNode, RefObject } from "react";
 
 import {
   Popover,
@@ -105,7 +105,10 @@ function UnhydratedSelectWithOther({
   required,
   children,
   className,
-}: SelectWithOtherProps) {
+  selectRef,
+}: SelectWithOtherProps & {
+  selectRef?: RefObject<HTMLSelectElement | null>;
+}) {
   const { selection, customValue } = resolveSelectState(
     options,
     defaultValue ?? undefined
@@ -131,6 +134,7 @@ function UnhydratedSelectWithOther({
         {label}
       </FieldLabel>
       <select
+        ref={selectRef}
         id={name}
         name={name}
         required={required}
@@ -172,12 +176,27 @@ function UnhydratedSelectWithOther({
  */
 export function SelectWithOther(props: SelectWithOtherProps) {
   const isHydrated = useHydrated();
+  const fallbackRef = useRef<HTMLSelectElement>(null);
 
   if (!isHydrated) {
-    return <UnhydratedSelectWithOther {...props} />;
+    return <UnhydratedSelectWithOther {...props} selectRef={fallbackRef} />;
   }
 
-  return <EnhancedSelectWithOther {...props} />;
+  /**
+   * The fallback is a real control, so on a slow connection the user can answer
+   * it before the bundle arrives. React has not committed its removal yet while
+   * this render runs, so read the live answer here: seeding the enhanced control
+   * from `defaultValue` alone would silently throw that answer away and leave a
+   * required field empty. `EnhancedSelectWithOther` only reads `defaultValue`
+   * to seed its initial state, so it does not matter that the ref is empty on
+   * later renders.
+   */
+  return (
+    <EnhancedSelectWithOther
+      {...props}
+      defaultValue={fallbackRef.current?.value || props.defaultValue}
+    />
+  );
 }
 
 function EnhancedSelectWithOther({


### PR DESCRIPTION
## The problem

`SelectWithOther` — the control behind **What's your role?** and **How many people will use this?** on `/onboarding` — renders a Radix popover whose selection is written into a hidden `<input>`. Nothing about it works before React hydrates:

- clicking the box does nothing, and there is no text field to type into;
- the hidden input stays empty, and both answers are required, so the form cannot be submitted either.

The result is a dead end on the first screen of the product: the user cannot finish signup and cannot get past it. Any browser that renders the page but never hydrates hits this — JavaScript blocked or broken by an extension, a bundle chunk that fails to load or parse, an engine too old for the build target.

This came in from a customer stuck on "Set up your account": both dropdowns ignored clicks and keystrokes, and submitting was blocked because the fields are required.

## The fix

Progressive enhancement, using the same `useHydrated` split the app's other dropdowns already use (`components/kits/actions-dropdown.tsx`):

- **Server render** is a native `<select>` carrying the same `name`. It submits with the plain form POST, supports keyboard type-ahead, and gets the browser's own required-field validation — no scripting involved.
- **After hydration** the existing styled popover takes over, unchanged. Exactly one control with the field's `name` is in the DOM at any time.

The fallback's `Other` option submits the literal string `"Other"`, which round-trips back through `resolveSelectState` into the enhanced control's free-text state, so nothing is lost if the page is re-rendered. A previously saved free-text answer gets its own `<option>` so the select can't silently drop it.

`SelectWithOther` is used only by the onboarding form, so the blast radius is that page.

## Verification

- Server-rendered HTML is a real `<select name="jobTitle" required>` with every option; the inert popover button is no longer what unhydrated browsers get.
- Hydrated behaviour unchanged in Chrome: the popover opens, picking an option sets the hidden input and updates the trigger.
- Fallback rendered on purpose and checked at desktop and mobile widths: same 44px height, border, radius and grey placeholder as the styled control.
- 6 new unit tests cover both halves of the contract; `pnpm lint`, `pnpm typecheck` and the forms suite pass.

## Known limits

- Without JS, picking **Personal use** cannot hide the team-size and company fields (that branch is client state), so those stay visible and required. Answerable, not blocking — the server already relaxes them for "Personal use".
- The optional "Help us customize Shelf" section stays collapsed without JS. Its fields are optional, so signup still completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a native select fallback before hydration, preserving saved preset and free-text answers.
  * Added required-field validation and consistent value submission across server-rendered and hydrated states.
  * Preserved the styled select control after hydration, including support for selecting “Other.”
  * Preserved selections made before hydration and applied default values when no answer was provided.

* **Tests**
  * Added coverage for server-rendered and hydrated select behavior, saved answers, field attributes, options, and form submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->