### PR TITLE
fix(companion): resume the paused scanner on any tap, and keep manual entry above the keyboard

### DIFF
--- a/apps/companion/.maestro/flows/scanner/11-paused-camera-resumes-on-tap.yaml
+++ b/apps/companion/.maestro/flows/scanner/11-paused-camera-resumes-on-tap.yaml
@@ -13,6 +13,12 @@ appId: com.shelf.companion.carlos
 - launchApp:
     appId: com.shelf.companion.carlos
     stopApp: false
+# The Scan tab keeps its last parameters, so a booking-mode scanner left by an
+# earlier flow would come back. The deep link opens the plain scanner.
+- openLink: "shelf://scanner"
+- tapOn:
+    text: "Open"
+    optional: true
 - tapOn: "Scan"
 - tapOn:
     text: "Allow"
@@ -27,6 +33,17 @@ appId: com.shelf.companion.carlos
     optional: true
 - tapOn:
     text: "Resume camera"
+    optional: true
+# A batch drawer left by an earlier flow covers the camera controls, and
+# switching the action with items scanned asks for confirmation.
+- tapOn:
+    text: "Clear all.*"
+    optional: true
+- tapOn:
+    text: "Scanner action: View.*"
+    optional: true
+- tapOn:
+    text: "Switch"
     optional: true
 - extendedWaitUntil:
     visible:

--- a/apps/companion/.maestro/flows/scanner/11-paused-camera-resumes-on-tap.yaml
+++ b/apps/companion/.maestro/flows/scanner/11-paused-camera-resumes-on-tap.yaml
@@ -1,0 +1,59 @@
+# Scanner — a paused camera resumes on a tap anywhere on the screen
+#
+# The paused layer sits under the overlay strips. The strips are `box-none`
+# and the swipe row is `none` while paused, so a tap on any spot that is not
+# a control reaches the paused layer. Both pause paths are covered:
+#   1. the pause button, then a tap in the empty bottom strip
+#   2. the 30 s inactivity auto-pause, then a tap inside the frame area
+#
+# No login step: runs against the session already on the simulator.
+appId: com.shelf.companion.carlos
+---
+# Bring the already signed-in app to the front without clearing its state.
+- launchApp:
+    appId: com.shelf.companion.carlos
+    stopApp: false
+- tapOn: "Scan"
+- tapOn:
+    text: "Allow"
+    optional: true
+# Leftovers from an earlier run on the same session: a result card hides the
+# manual entry, and an open manual-entry row replaces the "Enter code" pill.
+- tapOn:
+    text: ".*Tap to dismiss.*"
+    optional: true
+- tapOn:
+    text: "Close manual entry"
+    optional: true
+- tapOn:
+    text: "Resume camera"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: "dev-scan-toggle"
+    timeout: 15000
+
+# ── 1. Pause with the button, resume with a tap in the empty top strip ──
+- tapOn: "Pause camera"
+- extendedWaitUntil:
+    visible: "Camera paused.*"
+    timeout: 5000
+- takeScreenshot: scanner-paused-by-button
+- tapOn:
+    point: "50%,15%"
+- extendedWaitUntil:
+    notVisible: "Camera paused.*"
+    timeout: 5000
+- takeScreenshot: scanner-resumed-by-tap-top
+
+# ── 2. Inactivity auto-pause, resume with a tap inside the frame area ──
+- extendedWaitUntil:
+    visible: "Camera paused.*"
+    timeout: 45000
+- takeScreenshot: scanner-paused-by-inactivity
+- tapOn:
+    point: "50%,50%"
+- extendedWaitUntil:
+    notVisible: "Camera paused.*"
+    timeout: 5000
+- takeScreenshot: scanner-resumed-by-tap-frame

--- a/apps/companion/.maestro/flows/scanner/12-manual-entry-stays-above-keyboard.yaml
+++ b/apps/companion/.maestro/flows/scanner/12-manual-entry-stays-above-keyboard.yaml
@@ -13,6 +13,12 @@ appId: com.shelf.companion.carlos
 - launchApp:
     appId: com.shelf.companion.carlos
     stopApp: false
+# The Scan tab keeps its last parameters, so a booking-mode scanner left by an
+# earlier flow would come back. The deep link opens the plain scanner.
+- openLink: "shelf://scanner"
+- tapOn:
+    text: "Open"
+    optional: true
 - tapOn: "Scan"
 - tapOn:
     text: "Allow"
@@ -56,7 +62,15 @@ appId: com.shelf.companion.carlos
 - tapOn: "Close manual entry"
 
 # ── 2. Batch mode: four scanned items push the pill to the top strip ──
-- tapOn: "Scanner action: Assign"
+# The pill's label carries a state suffix once selected, and an earlier run
+# may have left items in the drawer.
+- tapOn: "Scanner action: Assign.*"
+- tapOn:
+    text: "Switch"
+    optional: true
+- tapOn:
+    text: "Clear all.*"
+    optional: true
 - extendedWaitUntil:
     visible:
       id: "dev-scan-toggle"

--- a/apps/companion/.maestro/flows/scanner/12-manual-entry-stays-above-keyboard.yaml
+++ b/apps/companion/.maestro/flows/scanner/12-manual-entry-stays-above-keyboard.yaml
@@ -1,0 +1,99 @@
+# Scanner — manual code entry opens in the top strip, above the keyboard
+#
+# "Enter code" opens the text field under the status bar, focused, so the
+# keyboard rising from the bottom never covers it. The lookup still runs on
+# Enter. Then, in a batch action, four typed codes grow the drawer until the
+# bottom strip has no room, and the closed pill moves to the top strip.
+#
+# Fixture: SAM-0001..SAM-0004 exist in GRANULAR WORKSPACE.
+# No login step: runs against the session already on the simulator.
+appId: com.shelf.companion.carlos
+---
+# Bring the already signed-in app to the front without clearing its state.
+- launchApp:
+    appId: com.shelf.companion.carlos
+    stopApp: false
+- tapOn: "Scan"
+- tapOn:
+    text: "Allow"
+    optional: true
+# Leftovers from an earlier run on the same session: a result card hides the
+# manual entry, and an open manual-entry row replaces the "Enter code" pill.
+- tapOn:
+    text: ".*Tap to dismiss.*"
+    optional: true
+- tapOn:
+    text: "Close manual entry"
+    optional: true
+- tapOn:
+    text: "Resume camera"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: "dev-scan-toggle"
+    timeout: 15000
+
+# ── 1. Open manual entry: field visible with the keyboard up ──
+- tapOn:
+    id: "dev-scan-toggle"
+- extendedWaitUntil:
+    visible:
+      id: "dev-scan-input"
+    timeout: 5000
+- takeScreenshot: manual-entry-open-above-keyboard
+- inputText: "SAM-9999"
+- pressKey: Enter
+- extendedWaitUntil:
+    visible: ".*SAM ID doesn't exist.*"
+    timeout: 15000
+- takeScreenshot: manual-entry-lookup-ran
+# The result card hides the manual entry while it is shown; dismiss it first.
+- tapOn: ".*Tap to dismiss.*"
+- extendedWaitUntil:
+    visible:
+      id: "dev-scan-input"
+    timeout: 5000
+- tapOn: "Close manual entry"
+
+# ── 2. Batch mode: four scanned items push the pill to the top strip ──
+- tapOn: "Scanner action: Assign"
+- extendedWaitUntil:
+    visible:
+      id: "dev-scan-toggle"
+    timeout: 5000
+- tapOn:
+    id: "dev-scan-toggle"
+- tapOn:
+    id: "dev-scan-input"
+- inputText: "SAM-0001"
+- pressKey: Enter
+- extendedWaitUntil:
+    visible: "1 item scanned"
+    timeout: 15000
+- tapOn:
+    id: "dev-scan-input"
+- inputText: "SAM-0002"
+- pressKey: Enter
+- extendedWaitUntil:
+    visible: "2 items scanned"
+    timeout: 15000
+- tapOn:
+    id: "dev-scan-input"
+- inputText: "SAM-0003"
+- pressKey: Enter
+- extendedWaitUntil:
+    visible: "3 items scanned"
+    timeout: 15000
+- tapOn:
+    id: "dev-scan-input"
+- inputText: "SAM-0004"
+- pressKey: Enter
+- extendedWaitUntil:
+    visible: "4 items scanned"
+    timeout: 15000
+- tapOn: "Close manual entry"
+# With four items the drawer leaves no room in the bottom strip, so the
+# closed pill sits in the top strip and stays reachable.
+- assertVisible:
+    id: "dev-scan-toggle"
+- takeScreenshot: manual-entry-pill-in-top-strip-with-drawer

--- a/apps/companion/.maestro/flows/scanner/13-booking-scanner-resumes-on-header-tap.yaml
+++ b/apps/companion/.maestro/flows/scanner/13-booking-scanner-resumes-on-header-tap.yaml
@@ -12,6 +12,12 @@ appId: com.shelf.companion.carlos
 - launchApp:
     appId: com.shelf.companion.carlos
     stopApp: false
+# The Bookings tab keeps its last screen, so an earlier flow may have left it
+# on a booking's detail page. The deep link opens the list.
+- openLink: "shelf://bookings"
+- tapOn:
+    text: "Open"
+    optional: true
 - tapOn: "Bookings"
 - extendedWaitUntil:
     visible: "Booking: .*"

--- a/apps/companion/.maestro/flows/scanner/13-booking-scanner-resumes-on-header-tap.yaml
+++ b/apps/companion/.maestro/flows/scanner/13-booking-scanner-resumes-on-header-tap.yaml
@@ -5,25 +5,38 @@
 # touches through, so a tap on the booking name reaches the paused layer while
 # the back button keeps working.
 #
-# Opens the first booking in the list that offers scan-to-add.
+# Opens the "QA Scan Booking" fixture (a DRAFT booking in the QA workspace,
+# the same one flows/bookings/02 uses), which always offers scan-to-add.
 # No login step: runs against the session already on the simulator.
 appId: com.shelf.companion.carlos
 ---
 - launchApp:
     appId: com.shelf.companion.carlos
     stopApp: false
-# The Bookings tab keeps its last screen, so an earlier flow may have left it
-# on a booking's detail page. The deep link opens the list.
-- openLink: "shelf://bookings"
-- tapOn:
-    text: "Open"
-    optional: true
 - tapOn: "Bookings"
-- extendedWaitUntil:
-    visible: "Booking: .*"
-    timeout: 15000
+# The Bookings tab keeps its last screen, so an earlier flow may have left it
+# on a booking's detail page.
 - tapOn:
-    text: "Booking: .*"
+    text: "Go back"
+    optional: true
+# DRAFT bookings live under the "All" filter. The filter pills scroll
+# horizontally and "All" sits off-screen to the right on a phone-sized screen.
+- extendedWaitUntil:
+    visible: "Filter: Active.*"
+    timeout: 15000
+- swipe:
+    start: "90%,21%"
+    end: "18%,21%"
+- swipe:
+    start: "90%,21%"
+    end: "18%,21%"
+- tapOn: "Filter: All.*"
+- scrollUntilVisible:
+    element:
+      text: ".*QA Scan Booking.*"
+    direction: DOWN
+    timeout: 60000
+- tapOn: ".*QA Scan Booking.*"
 - extendedWaitUntil:
     visible: ".*Scan assets or kits to add.*"
     timeout: 15000

--- a/apps/companion/.maestro/flows/scanner/13-booking-scanner-resumes-on-header-tap.yaml
+++ b/apps/companion/.maestro/flows/scanner/13-booking-scanner-resumes-on-header-tap.yaml
@@ -1,0 +1,46 @@
+# Scanner in booking mode — a paused camera resumes on a tap on the booking header
+#
+# The add-to-booking scanner replaces the action pills with a header (back
+# button, "ADD TO BOOKING", booking name). The header's label wrappers pass
+# touches through, so a tap on the booking name reaches the paused layer while
+# the back button keeps working.
+#
+# Opens the first booking in the list that offers scan-to-add.
+# No login step: runs against the session already on the simulator.
+appId: com.shelf.companion.carlos
+---
+- launchApp:
+    appId: com.shelf.companion.carlos
+    stopApp: false
+- tapOn: "Bookings"
+- extendedWaitUntil:
+    visible: "Booking: .*"
+    timeout: 15000
+- tapOn:
+    text: "Booking: .*"
+- extendedWaitUntil:
+    visible: ".*Scan assets or kits to add.*"
+    timeout: 15000
+- tapOn: ".*Scan assets or kits to add.*"
+- tapOn:
+    text: "Allow"
+    optional: true
+- extendedWaitUntil:
+    visible: "Scan assets or kits to add"
+    timeout: 15000
+# Pause with the button when it is reachable; otherwise the 30 s auto-pause.
+- tapOn:
+    text: "Pause camera"
+    optional: true
+- extendedWaitUntil:
+    visible: "Camera paused.*"
+    timeout: 45000
+- takeScreenshot: booking-scanner-paused
+# The booking name sits in the header at the bottom of the top strip.
+- tapOn:
+    point: "30%,27%"
+- extendedWaitUntil:
+    notVisible: "Camera paused.*"
+    timeout: 5000
+- takeScreenshot: booking-scanner-resumed-by-header-tap
+- tapOn: "Go back"

--- a/apps/companion/app/(tabs)/scanner.tsx
+++ b/apps/companion/app/(tabs)/scanner.tsx
@@ -1,6 +1,5 @@
 import { useState, useCallback, useRef, useMemo, useEffect } from "react";
 import {
-  useWindowDimensions,
   View,
   Text,
   TextInput,
@@ -13,6 +12,7 @@ import {
   Platform,
   Alert,
 } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import * as Haptics from "expo-haptics";
 import { useRouter, useLocalSearchParams } from "expo-router";
 import { useIsFocused } from "@react-navigation/native";
@@ -309,30 +309,7 @@ function ScannerContent() {
     if (!anyDrawerVisible) setDrawerHeight(0);
   }, [anyDrawerVisible]);
 
-  /**
-   * Where the floating manual-entry control sits, or `null` when it cannot be
-   * placed without overlapping something.
-   *
-   * It is anchored inside the bottom strip, which is roughly half the space
-   * left over after the 240px frame. Lifting it by the full drawer height
-   * clears the drawer but can push it up INTO the frame and over the
-   * instruction text — the drawer grows to 280px (400px with blockers), so on
-   * a short viewport no offset clears both. In that case we render nothing
-   * rather than recreate the overlap this fix exists to remove: the camera and
-   * the drawer's own actions still work, and clearing an item restores the gap.
-   */
-  const { height: windowHeight } = useWindowDimensions();
-  const manualEntryBottom = useMemo(() => {
-    const DEFAULT_BOTTOM = 90;
-    const CONTROL_HEIGHT = 48;
-    if (drawerHeight <= DEFAULT_BOTTOM) return DEFAULT_BOTTOM;
-
-    // Space between the frame's bottom edge and the screen bottom.
-    const stripHeight = (windowHeight - FRAME_SIZE) / 2;
-    const desired = drawerHeight + spacing.md;
-    const maxBottom = stripHeight - CONTROL_HEIGHT - spacing.md;
-    return desired > maxBottom ? null : desired;
-  }, [drawerHeight, windowHeight]);
+  const insets = useSafeAreaInsets();
 
   // Booking context for both booking modes. Add mode uses bookedAssetIds +
   // bookingStatus for its blockers (web parity); check-in mode uses the
@@ -415,6 +392,22 @@ function ScannerContent() {
   // Dev-mode scan injection (stripped from production builds)
   const [devScanInput, setDevScanInput] = useState("");
   const [devScanVisible, setDevScanVisible] = useState(false);
+
+  /**
+   * Absolute position of the manual-entry control.
+   *
+   * The open text field always lives in the top strip, just under the status
+   * bar: the keyboard rises from the bottom and would cover a field anchored
+   * there, and the top strip is free above the header and pills. The closed
+   * pill sits low in the bottom strip while nothing else is there, and moves
+   * to the top strip as soon as a drawer opens: the drawer shares the bottom
+   * strip with the hint text and the camera controls, and no offset keeps the
+   * pill clear of all three on a short screen.
+   */
+  const manualEntryPlacement =
+    devScanVisible || drawerHeight > 0
+      ? { top: insets.top + spacing.md }
+      : { bottom: MANUAL_ENTRY_BOTTOM };
 
   // Cooldown (shared hook)
   const {
@@ -2312,10 +2305,14 @@ function ScannerContent() {
         </TouchableOpacity>
       )}
 
-      {/* Overlay with cutout */}
-      <View style={styles.overlay}>
+      {/* Overlay with cutout.
+          `box-none` on the overlay and its strips: only real controls inside
+          them are touch targets, so a tap on an empty area falls through to
+          the paused layer beneath, which is what "tap anywhere to resume"
+          relies on. */}
+      <View style={styles.overlay} pointerEvents="box-none">
         {/* Top - Action picker or Booking header */}
-        <View style={styles.overlaySection}>
+        <View style={styles.overlaySection} pointerEvents="box-none">
           {isBookingMode ? (
             <View style={styles.actionPickerContainer}>
               <View style={styles.bookingModeHeader}>
@@ -2369,8 +2366,13 @@ function ScannerContent() {
           )}
         </View>
 
-        {/* Middle row -- swipe gesture target */}
-        <View style={styles.middleRow} {...panResponder.panHandlers}>
+        {/* Middle row -- swipe gesture target. Switched off while paused so
+            the tap lands on the paused layer instead of the swipe surface. */}
+        <View
+          style={styles.middleRow}
+          pointerEvents={isPaused ? "none" : "auto"}
+          {...panResponder.panHandlers}
+        >
           <View style={styles.overlaySection} />
           <ScanFrame
             scanLineAnim={scanLineAnim}
@@ -2398,13 +2400,17 @@ function ScannerContent() {
            * it never needed the overlay to make room in the first place.
            */
           style={[styles.overlaySection, styles.bottomSection]}
+          pointerEvents="box-none"
         >
           {/* Mode indicator dots */}
           {!isBookingMode && (
-            <ModeDots actions={availableActions} currentAction={action} />
+            <View pointerEvents="none">
+              <ModeDots actions={availableActions} currentAction={action} />
+            </View>
           )}
 
-          {/* Status / instruction text -- animated for swipe transitions */}
+          {/* Status / instruction text -- animated for swipe transitions.
+              Only the result card takes touches; plain text lets them pass. */}
           <Animated.View
             style={[
               styles.instructionContainer,
@@ -2413,6 +2419,7 @@ function ScannerContent() {
                 opacity: swipeOpacity,
               },
             ]}
+            pointerEvents={scanResult ? "auto" : "none"}
           >
             {isProcessing && !scanResult ? (
               <View style={styles.statusRow}>
@@ -2435,7 +2442,7 @@ function ScannerContent() {
           </Animated.View>
 
           {/* Camera controls -- positioned in the thumb-friendly bottom zone */}
-          <View style={styles.controlButtons}>
+          <View style={styles.controlButtons} pointerEvents="box-none">
             {/* Pause/Resume toggle */}
             <TouchableOpacity
               style={[
@@ -2485,14 +2492,13 @@ function ScannerContent() {
             control's origin so the existing e2e flows stay stable. */}
         {/* Hidden while a result card is shown — the card's actions must never
             be occluded (the unclaimed card is tall enough to reach this pill). */}
-        {manualEntryBottom !== null && !scanResult && (
+        {!scanResult && (
           <View
-            style={[
-              styles.devScanContainer,
-              // Clamped so the lift never pushes the control into the scan
-              // frame; see `manualEntryBottom`.
-              { bottom: manualEntryBottom },
-            ]}
+            style={[styles.devScanContainer, manualEntryPlacement]}
+            // Full-width host: only the pill or the field inside it takes
+            // touches, so a tap beside them reaches the paused layer.
+            pointerEvents="box-none"
+            testID="manual-entry-container"
           >
             {devScanVisible ? (
               <View style={styles.devScanRow}>
@@ -2501,6 +2507,9 @@ function ScannerContent() {
                   style={styles.devScanInput}
                   value={devScanInput}
                   onChangeText={setDevScanInput}
+                  // Opens the keyboard as soon as the field appears, so one tap
+                  // on "Enter code" is enough to start typing.
+                  autoFocus
                   placeholder="Enter QR, barcode, or SAM ID"
                   placeholderTextColor="rgba(255,255,255,0.4)"
                   autoCapitalize="none"
@@ -2707,6 +2716,8 @@ export default function ScannerScreen() {
 // ── Styles ────────────────────────────────────────────────
 
 const FRAME_SIZE = 240;
+/** Distance of the closed "Enter code" pill from the bottom edge when no drawer is open. */
+const MANUAL_ENTRY_BOTTOM = 90;
 
 const useStyles = createStyles((colors) => ({
   container: {
@@ -2766,6 +2777,9 @@ const useStyles = createStyles((colors) => ({
     // why: no zIndex — the action pills / batch drawer (later siblings) must
     // win hit-testing, otherwise this full-screen touchable swallows the
     // first tap aimed at them while paused. It still covers the camera area.
+    // The overlay strips above it are `box-none` (and the swipe row `none`
+    // while paused), so a tap on anything that is not a control reaches this
+    // layer and resumes the camera.
   },
   pausedTitle: {
     color: "#fff",
@@ -2870,7 +2884,6 @@ const useStyles = createStyles((colors) => ({
   // ── Dev Scan Injection (DEV only) ───────────────
   devScanContainer: {
     position: "absolute" as const,
-    bottom: 90,
     left: spacing.md,
     right: spacing.md,
     zIndex: 999,

--- a/apps/companion/app/(tabs)/scanner.tsx
+++ b/apps/companion/app/(tabs)/scanner.tsx
@@ -2314,8 +2314,8 @@ function ScannerContent() {
         {/* Top - Action picker or Booking header */}
         <View style={styles.overlaySection} pointerEvents="box-none">
           {isBookingMode ? (
-            <View style={styles.actionPickerContainer}>
-              <View style={styles.bookingModeHeader}>
+            <View style={styles.actionPickerContainer} pointerEvents="box-none">
+              <View style={styles.bookingModeHeader} pointerEvents="box-none">
                 <TouchableOpacity
                   onPress={() => router.back()}
                   accessibilityLabel="Go back"
@@ -2323,7 +2323,8 @@ function ScannerContent() {
                 >
                   <Ionicons name="arrow-back" size={22} color="#fff" />
                 </TouchableOpacity>
-                <View style={styles.bookingModeInfo}>
+                {/* Labels only: touches pass through to the paused layer. */}
+                <View style={styles.bookingModeInfo} pointerEvents="none">
                   <Text style={styles.bookingModeLabel}>
                     {isBookingFulfilMode
                       ? "Fulfil & Check Out"
@@ -2352,7 +2353,7 @@ function ScannerContent() {
               </View>
             </View>
           ) : (
-            <View style={styles.actionPickerContainer}>
+            <View style={styles.actionPickerContainer} pointerEvents="box-none">
               <ActionPills
                 actions={availableActions}
                 currentAction={action}


### PR DESCRIPTION
## The report

Two scanner complaints from one iPhone 17 user on app 1.5, both reproduced from the code:

1. The camera pauses after 30 s of inactivity and shows "Tap anywhere to resume scanning", but tapping the screen does nothing. Only the small play button under the frame resumes it.
2. "Enter code" opens a text field at the bottom of the camera view and the keyboard opens over it, so nothing typed is visible. With a full drawer of scanned items the field also overlaps the hint text under the frame.

## Root cause

**Resume.** The paused layer is a full-screen `TouchableOpacity` rendered *before* the overlay strips. The overlay `View` is `absoluteFill` with three flex strips that carry a background, and none of them had `pointerEvents` set. In React Native the deepest view under a touch becomes the target and the responder walk goes up its ancestors only, so every tap landed on a strip and the paused layer, a sibling underneath, never saw it. The play button works because it is a child of a strip.

**Manual entry.** The control is absolutely positioned near the bottom of the overlay (`bottom: 90`, lifted by the drawer height) and nothing accounts for the keyboard. The drawer clamp keeps it out of the 240 px frame but not out of the hint text, and hides the control entirely when the drawer leaves no room.

## The fix

**Resume.** The overlay and its top and bottom strips are `pointerEvents="box-none"`, so only real controls inside them (pills, back button, play/torch buttons, manual entry, drawers) are touch targets. The swipe row is `pointerEvents="none"` while paused, and the mode dots and plain instruction text pass touches through (the result card keeps them). A tap on anything that is not a control now reaches the paused layer. The pills and the drawer stay tappable while paused, which is what the layer's missing `zIndex` protects.

**Manual entry.** The open text field always renders in the top strip, just under the status bar, with `autoFocus`, so the keyboard rising from the bottom never covers it and one tap on "Enter code" starts typing. The closed pill sits low in the bottom strip while nothing else is there and moves to the top strip as soon as a drawer opens: the drawer shares the bottom strip with the hint text and the camera controls, and no offset keeps the pill clear of all three on a short screen. The old drawer-height arithmetic (and its `useWindowDimensions` read, which measured the screen rather than the tab content area) is gone.

No server change, no native change: ships over the air.

## Proof on the iPhone 17 simulator

Two new Maestro flows, run against the signed-in QA session:

- `scanner/11-paused-camera-resumes-on-tap.yaml`: pause with the button, tap empty space in the bottom strip, camera resumes; wait for the 30 s auto-pause, tap inside the frame area, camera resumes.
- `scanner/12-manual-entry-stays-above-keyboard.yaml`: "Enter code" opens the field in the top strip with the keyboard up, a typed SAM id runs the lookup; in Assign custody mode four typed codes fill the drawer and the closed pill sits in the top strip.

Red check: with the scanner file reverted to main, flow 11 fails at the first resume assertion (the tap in the empty top strip does not resume); with this change both flows pass. The flows take their own screenshots (`scanner-resumed-by-tap-top`, `scanner-resumed-by-tap-frame`, `manual-entry-open-above-keyboard`, `manual-entry-pill-in-top-strip-with-drawer`) on any signed-in simulator; the run's set is available on request. Typecheck and `expo lint` clean.

## Not in this PR

- The audit scanner (`audits/scan.tsx`) already sets `box-none` on its overlay and hides the frame while paused; its header row still swallows taps in its own band. Left as is.
- Booking-mode scanning shares this screen, so the same fix applies there; the flows cover the Scan tab only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added booking check-out support to the scanner, including kit and asset scanning, quantity tracking, and remaining-asset feedback.
  - Improved scanner navigation and labels during booking check-out.

- **Bug Fixes**
  - Improved paused-camera resume behavior from header and non-scan-area taps.
  - Manual code entry remains visible above the keyboard during batch entry and drawer interactions.

- **Tests**
  - Added automated coverage for scanner resume behavior, booking selection, check-out flows, manual entry validation, and batch entry layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->