### PR TITLE
fix(billing): keep barcodes through an add-on lapse and end bundled add-ons with the tier

### DIFF
--- a/apps/webapp/app/modules/stripe-webhook/handlers.server.test.ts
+++ b/apps/webapp/app/modules/stripe-webhook/handlers.server.test.ts
@@ -1,0 +1,410 @@
+/**
+ * Stripe webhook handlers — add-ons bundled on a tier subscription.
+ *
+ * A Team trial or checkout can carry the Audits and Barcodes add-ons as extra
+ * line items on the tier subscription. Once workspace creation has linked that
+ * subscription to an organization, the organization's add-on flags follow the
+ * subscription's lifecycle exactly as they do for a standalone add-on
+ * subscription: paused or cancelled means off, an item dropped from the
+ * subscription means off, and the add-on handlers see every status change.
+ */
+import { TierId } from "@prisma/client";
+import type Stripe from "stripe";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// why: env module reads process.env at import time; the webhook helpers need
+// the admin/webhook values to exist
+vi.mock(import("~/utils/env"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    STRIPE_WEBHOOK_ENDPOINT_SECRET: "whsec_test",
+    ADMIN_EMAIL: undefined,
+    CUSTOM_INSTALL_CUSTOMERS: "",
+    SERVER_URL: "https://app.shelf.nu",
+  };
+});
+
+// why: Database module connects to Prisma during import
+const { mockUserUpdate, mockOrgUpdate } = vi.hoisted(() => ({
+  mockUserUpdate: vi.fn(),
+  mockOrgUpdate: vi.fn(),
+}));
+vi.mock("~/database/db.server", () => ({
+  db: {
+    user: { update: mockUserUpdate },
+    organization: { update: mockOrgUpdate },
+  },
+}));
+
+// why: Stripe SDK makes external API calls. The event parser is where line
+// items are resolved to tier/add-on products, so each test states its result.
+const { mockGetDataFromStripeEvent, mockProductsRetrieve } = vi.hoisted(() => ({
+  mockGetDataFromStripeEvent: vi.fn(),
+  mockProductsRetrieve: vi.fn(),
+}));
+vi.mock("~/utils/stripe.server", () => ({
+  stripe: {
+    products: { retrieve: mockProductsRetrieve },
+    subscriptions: { update: vi.fn() },
+  },
+  getDataFromStripeEvent: mockGetDataFromStripeEvent,
+  customerHasPaymentMethod: vi.fn(),
+  fetchStripeSubscription: vi.fn(),
+  getCustomerActiveSubscription: vi.fn(),
+  getCustomerNotificationData: vi.fn(),
+  getInvoiceNotificationData: vi.fn(),
+  getStripeCustomer: vi.fn(),
+}));
+
+// why: the add-on handlers are the collaborators under test — what matters is
+// that the tier branch reaches them with the event, not what they write
+const { mockAuditAddonWebhook, mockBarcodeAddonWebhook } = vi.hoisted(() => ({
+  mockAuditAddonWebhook: vi.fn(),
+  mockBarcodeAddonWebhook: vi.fn(),
+}));
+vi.mock("~/modules/audit/addon.server", () => ({
+  handleAuditAddonWebhook: mockAuditAddonWebhook,
+}));
+vi.mock("~/modules/barcode/addon.server", () => ({
+  handleBarcodeAddonWebhook: mockBarcodeAddonWebhook,
+}));
+
+// why: email, analytics, scheduler, branding and date-pref modules reach
+// external services or the database
+vi.mock("~/emails/mail.server", () => ({ sendEmail: vi.fn() }));
+vi.mock("~/emails/stripe/audit-trial-ends-soon", () => ({
+  sendAuditTrialEndsSoonEmail: vi.fn(),
+}));
+vi.mock("~/emails/stripe/barcode-trial-ends-soon", () => ({
+  sendBarcodeTrialEndsSoonEmail: vi.fn(),
+}));
+vi.mock("~/emails/stripe/subscription-granted", () => ({
+  subscriptionGrantedText: vi.fn(),
+}));
+vi.mock("~/emails/stripe/trial-ends-soon", () => ({
+  sendTrialEndsSoonEmail: vi.fn(),
+}));
+vi.mock("~/emails/stripe/unpaid-invoice", () => ({
+  unpaidInvoiceUserText: vi.fn(),
+  unpaidInvoiceAdminText: vi.fn(),
+}));
+vi.mock("~/emails/stripe/welcome-to-trial", () => ({
+  sendTeamTrialWelcomeEmail: vi.fn(),
+}));
+vi.mock("~/integrations/posthog/client.server", () => ({
+  captureServerEvent: vi.fn(),
+}));
+vi.mock("~/modules/addon-trial/scheduler.server", () => ({
+  scheduleTrialEndsTomorrowEmail: vi.fn(),
+}));
+vi.mock("~/modules/organization/service.server", () => ({
+  resetPersonalWorkspaceBranding: vi.fn(),
+}));
+vi.mock("~/utils/date-format.server", () => ({
+  resolveUserFormatPrefsById: vi.fn(),
+}));
+// why: Logger makes external calls
+vi.mock("~/utils/logger", () => ({
+  Logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import {
+  handleSubscriptionDeleted,
+  handleSubscriptionPaused,
+  handleSubscriptionUpdated,
+} from "./handlers.server";
+import type { WebhookUser } from "./helpers.server";
+
+const TEAM_PRODUCT = "prod_team";
+const BARCODES_PRODUCT = "prod_barcodes";
+const AUDITS_PRODUCT = "prod_audits";
+
+const user = {
+  id: "user-1",
+  email: "owner@example.com",
+  tierId: TierId.tier_2,
+  warnForNoPaymentMethod: false,
+  firstName: "Alice",
+  lastName: "Owner",
+} as WebhookUser;
+
+/** A subscription carrying one line item per product id. */
+function buildSubscription({
+  productIds = [TEAM_PRODUCT],
+  status = "active",
+  metadata = { organizationId: "org-1" },
+}: {
+  productIds?: string[];
+  status?: Stripe.Subscription.Status;
+  metadata?: Record<string, string>;
+} = {}): Stripe.Subscription {
+  return {
+    id: "sub_1",
+    customer: "cus_1",
+    status,
+    metadata,
+    trial_end: null,
+    items: {
+      data: productIds.map((product, index) => ({
+        id: `si_${index}`,
+        price: { id: `price_${product}`, product },
+      })),
+    },
+  } as unknown as Stripe.Subscription;
+}
+
+function buildEvent(
+  type: string,
+  subscription: Stripe.Subscription,
+  previousAttributes?: Record<string, unknown>
+): Stripe.Event {
+  return {
+    id: "evt_1",
+    type,
+    data: { object: subscription, previous_attributes: previousAttributes },
+  } as unknown as Stripe.Event;
+}
+
+/** What the event parser returns for a tier subscription, bundled or not. */
+function parsedTierSubscription(subscription: Stripe.Subscription) {
+  const productIds = subscription.items.data.map((item) =>
+    typeof item.price.product === "string" ? item.price.product : ""
+  );
+  return {
+    subscription,
+    customerId: "cus_1",
+    tierId: "tier_2",
+    productType: undefined,
+    product: { id: TEAM_PRODUCT, metadata: { shelf_tier: "tier_2" } },
+    hasAuditAddon: productIds.includes(AUDITS_PRODUCT),
+    hasBarcodeAddon: productIds.includes(BARCODES_PRODUCT),
+  };
+}
+
+/** What the event parser returns for a standalone add-on subscription. */
+function parsedAddonSubscription(subscription: Stripe.Subscription) {
+  return {
+    subscription,
+    customerId: "cus_1",
+    tierId: undefined,
+    productType: "addon",
+    product: {
+      id: BARCODES_PRODUCT,
+      metadata: { product_type: "addon", addon_type: "barcodes" },
+    },
+    hasAuditAddon: false,
+    hasBarcodeAddon: true,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUserUpdate.mockResolvedValue({ id: "user-1" });
+  mockOrgUpdate.mockResolvedValue({ id: "org-1" });
+});
+
+describe("handleSubscriptionPaused", () => {
+  it("pauses the add-ons bundled on a tier subscription and still downgrades the user", async () => {
+    const subscription = buildSubscription({
+      productIds: [TEAM_PRODUCT, BARCODES_PRODUCT],
+      status: "paused",
+    });
+    mockGetDataFromStripeEvent.mockResolvedValue(
+      parsedTierSubscription(subscription)
+    );
+
+    await handleSubscriptionPaused(
+      buildEvent("customer.subscription.paused", subscription),
+      user
+    );
+
+    expect(mockBarcodeAddonWebhook).toHaveBeenCalledWith({
+      eventType: "customer.subscription.paused",
+      subscription,
+      organizationId: "org-1",
+    });
+    expect(mockAuditAddonWebhook).not.toHaveBeenCalled();
+    expect(mockUserUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { tierId: "free" } })
+    );
+  });
+
+  it("leaves the add-on handlers alone for a tier-only subscription", async () => {
+    const subscription = buildSubscription({ status: "paused" });
+    mockGetDataFromStripeEvent.mockResolvedValue(
+      parsedTierSubscription(subscription)
+    );
+
+    await handleSubscriptionPaused(
+      buildEvent("customer.subscription.paused", subscription),
+      user
+    );
+
+    expect(mockBarcodeAddonWebhook).not.toHaveBeenCalled();
+    expect(mockAuditAddonWebhook).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for bundled add-ons that were never linked to a workspace", async () => {
+    const subscription = buildSubscription({
+      productIds: [TEAM_PRODUCT, BARCODES_PRODUCT],
+      status: "paused",
+      metadata: {},
+    });
+    mockGetDataFromStripeEvent.mockResolvedValue(
+      parsedTierSubscription(subscription)
+    );
+
+    await handleSubscriptionPaused(
+      buildEvent("customer.subscription.paused", subscription),
+      user
+    );
+
+    expect(mockBarcodeAddonWebhook).not.toHaveBeenCalled();
+  });
+
+  it("keeps routing a standalone add-on subscription to its handler without touching the tier", async () => {
+    const subscription = buildSubscription({
+      productIds: [BARCODES_PRODUCT],
+      status: "paused",
+    });
+    mockGetDataFromStripeEvent.mockResolvedValue(
+      parsedAddonSubscription(subscription)
+    );
+
+    await handleSubscriptionPaused(
+      buildEvent("customer.subscription.paused", subscription),
+      user
+    );
+
+    expect(mockBarcodeAddonWebhook).toHaveBeenCalledTimes(1);
+    expect(mockUserUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleSubscriptionDeleted", () => {
+  it("cancels every add-on bundled on the tier subscription", async () => {
+    const subscription = buildSubscription({
+      productIds: [TEAM_PRODUCT, AUDITS_PRODUCT, BARCODES_PRODUCT],
+      status: "canceled",
+    });
+    mockGetDataFromStripeEvent.mockResolvedValue(
+      parsedTierSubscription(subscription)
+    );
+
+    await handleSubscriptionDeleted(
+      buildEvent("customer.subscription.deleted", subscription),
+      user
+    );
+
+    expect(mockAuditAddonWebhook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "customer.subscription.deleted",
+        organizationId: "org-1",
+      })
+    );
+    expect(mockBarcodeAddonWebhook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "customer.subscription.deleted",
+        organizationId: "org-1",
+      })
+    );
+  });
+
+  it("keeps the add-ons when the cancellation is one side of a transfer", async () => {
+    const subscription = buildSubscription({
+      productIds: [TEAM_PRODUCT, BARCODES_PRODUCT],
+      status: "canceled",
+      metadata: {
+        organizationId: "org-1",
+        transferred_to_subscription: "sub_2",
+      },
+    });
+    mockGetDataFromStripeEvent.mockResolvedValue(
+      parsedTierSubscription(subscription)
+    );
+
+    await handleSubscriptionDeleted(
+      buildEvent("customer.subscription.deleted", subscription),
+      user
+    );
+
+    expect(mockBarcodeAddonWebhook).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleSubscriptionUpdated", () => {
+  it("passes the tier subscription's status change on to its bundled add-ons", async () => {
+    const subscription = buildSubscription({
+      productIds: [TEAM_PRODUCT, BARCODES_PRODUCT],
+      status: "past_due",
+    });
+    mockGetDataFromStripeEvent.mockResolvedValue(
+      parsedTierSubscription(subscription)
+    );
+
+    await handleSubscriptionUpdated(
+      buildEvent("customer.subscription.updated", subscription, {
+        status: "active",
+      }),
+      user
+    );
+
+    expect(mockBarcodeAddonWebhook).toHaveBeenCalledWith({
+      eventType: "customer.subscription.updated",
+      subscription,
+      organizationId: "org-1",
+    });
+  });
+
+  it("switches off an add-on whose line item was removed from the subscription", async () => {
+    const subscription = buildSubscription({ productIds: [TEAM_PRODUCT] });
+    mockGetDataFromStripeEvent.mockResolvedValue(
+      parsedTierSubscription(subscription)
+    );
+    mockProductsRetrieve.mockResolvedValue({
+      id: BARCODES_PRODUCT,
+      metadata: { product_type: "addon", addon_type: "barcodes" },
+    });
+
+    await handleSubscriptionUpdated(
+      buildEvent("customer.subscription.updated", subscription, {
+        items: {
+          data: buildSubscription({
+            productIds: [TEAM_PRODUCT, BARCODES_PRODUCT],
+          }).items.data,
+        },
+      }),
+      user
+    );
+
+    expect(mockProductsRetrieve).toHaveBeenCalledWith(BARCODES_PRODUCT);
+    expect(mockOrgUpdate).toHaveBeenCalledWith({
+      where: { id: "org-1" },
+      data: { barcodesEnabled: false },
+      select: { id: true },
+    });
+    // The add-on is no longer on the subscription, so its handler is not run.
+    expect(mockBarcodeAddonWebhook).not.toHaveBeenCalled();
+  });
+
+  it("ignores item updates that keep the same products", async () => {
+    const subscription = buildSubscription({
+      productIds: [TEAM_PRODUCT, BARCODES_PRODUCT],
+    });
+    mockGetDataFromStripeEvent.mockResolvedValue(
+      parsedTierSubscription(subscription)
+    );
+
+    await handleSubscriptionUpdated(
+      buildEvent("customer.subscription.updated", subscription, {
+        items: { data: subscription.items.data },
+      }),
+      user
+    );
+
+    expect(mockProductsRetrieve).not.toHaveBeenCalled();
+    expect(mockOrgUpdate).not.toHaveBeenCalled();
+    expect(mockBarcodeAddonWebhook).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/webapp/app/modules/stripe-webhook/handlers.server.ts
+++ b/apps/webapp/app/modules/stripe-webhook/handlers.server.ts
@@ -40,6 +40,109 @@ import {
 const OK = () => new Response(null, { status: 200 });
 
 /**
+ * Applies a tier subscription's lifecycle event to the add-ons bundled on it.
+ *
+ * A Team trial or checkout can carry the Audits and Barcodes add-ons as extra
+ * line items on the tier subscription (`createTeamTrialSubscription`,
+ * `createStripeCheckoutSession`). Workspace creation links that subscription
+ * to the new organization through `metadata.organizationId` and switches the
+ * add-ons on; from then on they live and die with the tier subscription, so
+ * its pauses, cancellations and status changes have to reach the same
+ * organization flags the standalone add-on handlers maintain.
+ *
+ * Only add-ons present on this subscription are touched. A workspace can also
+ * hold a standalone add-on subscription, and that one is governed by its own
+ * webhook events.
+ *
+ * @param args.eventType - The Stripe event type being handled
+ * @param args.subscription - The tier subscription from the event
+ * @param args.hasAuditAddon - Whether the subscription carries an Audits item
+ * @param args.hasBarcodeAddon - Whether the subscription carries a Barcodes item
+ */
+async function syncBundledAddons({
+  eventType,
+  subscription,
+  hasAuditAddon,
+  hasBarcodeAddon,
+}: {
+  eventType: string;
+  subscription: Stripe.Subscription;
+  hasAuditAddon: boolean;
+  hasBarcodeAddon: boolean;
+}) {
+  const organizationId = subscription.metadata?.organizationId;
+  if (!organizationId) return;
+
+  if (hasAuditAddon) {
+    await handleAuditAddonWebhook({ eventType, subscription, organizationId });
+  }
+  if (hasBarcodeAddon) {
+    await handleBarcodeAddonWebhook({
+      eventType,
+      subscription,
+      organizationId,
+    });
+  }
+}
+
+/**
+ * Switches off the add-ons an update removed from a tier subscription.
+ *
+ * Stripe lists the pre-update line items in `previous_attributes.items`. An
+ * add-on item that was there and is gone now has been dropped from the
+ * subscription, which for the workspace is the same as cancelling it.
+ *
+ * @param args.event - The `customer.subscription.updated` event
+ * @param args.subscription - The subscription as it is after the update
+ */
+async function disableAddonsRemovedFromSubscription({
+  event,
+  subscription,
+}: {
+  event: Stripe.Event;
+  subscription: Stripe.Subscription;
+}) {
+  const organizationId = subscription.metadata?.organizationId;
+  if (!organizationId) return;
+
+  const previousItems = (
+    event.data.previous_attributes as
+      | { items?: { data?: Stripe.SubscriptionItem[] } }
+      | undefined
+  )?.items?.data;
+  if (!previousItems?.length) return;
+
+  const productIdOf = (item: Stripe.SubscriptionItem) =>
+    typeof item.price?.product === "string"
+      ? item.price.product
+      : item.price?.product?.id;
+  const currentProductIds = new Set(subscription.items.data.map(productIdOf));
+
+  const removed: { auditsEnabled?: false; barcodesEnabled?: false } = {};
+  for (const item of previousItems) {
+    const productId = productIdOf(item);
+    if (!productId || currentProductIds.has(productId)) continue;
+
+    // Same metadata reading as `getDataFromStripeEvent`: an archived add-on
+    // product is still an add-on for the purpose of taking it away.
+    const product = await stripe.products.retrieve(productId);
+    if (product.metadata?.product_type !== "addon") continue;
+    if (product.metadata.addon_type === "audits") removed.auditsEnabled = false;
+    if (product.metadata.addon_type === "barcodes") {
+      removed.barcodesEnabled = false;
+    }
+  }
+
+  if (Object.keys(removed).length === 0) return;
+
+  await db.organization.update({
+    where: { id: organizationId },
+    data: removed,
+    select: { id: true },
+  });
+}
+
+/**
  * Builds the `upgrade_completed` PostHog properties from a Stripe subscription.
  * Normalises the recurring price to a monthly figure (`mrr`) so monthly,
  * yearly, weekly and daily plans are comparable; `mrr` is `null` when the plan
@@ -292,8 +395,15 @@ export async function handleSubscriptionPaused(
   event: Stripe.Event,
   user: WebhookUser
 ) {
-  const { subscription, customerId, tierId, productType, product } =
-    await getDataFromStripeEvent(event);
+  const {
+    subscription,
+    customerId,
+    tierId,
+    productType,
+    product,
+    hasAuditAddon,
+    hasBarcodeAddon,
+  } = await getDataFromStripeEvent(event);
 
   if (
     isAddonSubscription({
@@ -320,6 +430,13 @@ export async function handleSubscriptionPaused(
     }
     return OK();
   }
+
+  await syncBundledAddons({
+    eventType: event.type,
+    subscription,
+    hasAuditAddon,
+    hasBarcodeAddon,
+  });
 
   const pausedSubscriptionIsHigherOrEqualTier = isHigherOrEqualTier(
     tierId as TierId,
@@ -361,8 +478,15 @@ export async function handleSubscriptionUpdated(
   event: Stripe.Event,
   user: WebhookUser
 ) {
-  const { subscription, customerId, tierId, productType, product } =
-    await getDataFromStripeEvent(event);
+  const {
+    subscription,
+    customerId,
+    tierId,
+    productType,
+    product,
+    hasAuditAddon,
+    hasBarcodeAddon,
+  } = await getDataFromStripeEvent(event);
 
   if (
     isAddonSubscription({
@@ -389,6 +513,14 @@ export async function handleSubscriptionUpdated(
     }
     return OK();
   }
+
+  await syncBundledAddons({
+    eventType: event.type,
+    subscription,
+    hasAuditAddon,
+    hasBarcodeAddon,
+  });
+  await disableAddonsRemovedFromSubscription({ event, subscription });
 
   const newSubscriptionIsHigherTier = isHigherTier(
     tierId as TierId,
@@ -452,8 +584,15 @@ export async function handleSubscriptionDeleted(
   event: Stripe.Event,
   user: WebhookUser
 ) {
-  const { subscription, customerId, tierId, productType, product } =
-    await getDataFromStripeEvent(event);
+  const {
+    subscription,
+    customerId,
+    tierId,
+    productType,
+    product,
+    hasAuditAddon,
+    hasBarcodeAddon,
+  } = await getDataFromStripeEvent(event);
 
   if (isAddonSubscription({ tierId, productType, event })) {
     const organizationId = subscription?.metadata?.organizationId;
@@ -482,6 +621,17 @@ export async function handleSubscriptionDeleted(
       });
     }
     return OK();
+  }
+
+  // A transfer cancels the old subscription only after its replacement exists
+  // with the same items and metadata, so the add-ons stay with the workspace.
+  if (!subscription?.metadata?.transferred_to_subscription) {
+    await syncBundledAddons({
+      eventType: event.type,
+      subscription,
+      hasAuditAddon,
+      hasBarcodeAddon,
+    });
   }
 
   const deletedSubscriptionIsHigherOrEqualTier = isHigherOrEqualTier(

--- a/apps/webapp/app/routes/_layout+/assets.$assetId_.edit.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId_.edit.tsx
@@ -252,10 +252,15 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
     /** This checks if tags are passed and build the  */
     const tags = buildTagsSet(parsedData.tags);
 
-    /** Extract barcode data from form */
+    /**
+     * Barcodes are only read when the workspace holds the add-on. Without it
+     * the form has no barcode section, so `undefined` leaves the asset's
+     * existing barcodes untouched: `updateAsset` only reconciles a list it is
+     * given, and an empty list would read as "remove every barcode".
+     */
     const barcodes = canUseBarcodes
       ? extractBarcodesFromFormData(formData)
-      : [];
+      : undefined;
 
     await updateAsset({
       id,

--- a/apps/webapp/app/routes/_layout+/kits.$kitId_.edit.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId_.edit.tsx
@@ -141,10 +141,15 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       additionalData: { userId, kitId, organizationId },
     });
 
-    /** Extract barcode data from form */
+    /**
+     * Barcodes are only read when the workspace holds the add-on. Without it
+     * the form has no barcode section, so `undefined` leaves the kit's
+     * existing barcodes untouched: `updateKit` only reconciles a list it is
+     * given, and an empty list would read as "remove every barcode".
+     */
     const barcodes = canUseBarcodes
       ? extractBarcodesFromFormData(formData)
-      : [];
+      : undefined;
 
     // Get current kit to compare location changes
     const currentKit = await getKit({

--- a/apps/webapp/test/routes-tests/_layout+/assets.$assetId_.edit.barcodes-without-addon.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/assets.$assetId_.edit.barcodes-without-addon.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Asset edit route — barcodes are left alone when the workspace has no add-on.
+ *
+ * `updateAsset` reconciles the barcode list it is given against the barcodes
+ * on the asset and deletes whatever is missing from that list. A workspace
+ * without the alternative-barcodes add-on submits no barcode fields at all
+ * (the form hides the section), so the action must hand `updateAsset` no list
+ * rather than an empty one: barcode rows survive an add-on lapse and are back
+ * the moment the add-on is switched on again.
+ *
+ * @see {@link file://./../../../app/routes/_layout+/assets.$assetId_.edit.tsx}
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { action } from "~/routes/_layout+/assets.$assetId_.edit";
+
+// why: the route pulls the whole asset service graph (Prisma client, Supabase
+// storage, permissions); stubbing at the module boundary keeps this a unit test
+// of what the action hands to updateAsset.
+vi.mock("~/modules/asset/service.server", () => ({
+  getAllEntriesForCreateAndEdit: vi.fn(),
+  getAsset: vi.fn(),
+  updateAsset: vi.fn().mockResolvedValue({ id: "asset-1", title: "A" }),
+  updateAssetMainImage: vi.fn().mockResolvedValue(false),
+}));
+vi.mock("~/modules/custom-field/service.server", () => ({
+  getActiveCustomFields: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("~/modules/tag/service.server", () => ({
+  buildTagsSet: vi.fn().mockReturnValue({ set: [] }),
+}));
+vi.mock("~/modules/asset-model/service.server", () => ({
+  getAssetModels: vi
+    .fn()
+    .mockResolvedValue({ assetModels: [], totalAssetModels: 0 }),
+}));
+// why: permission resolution is an auth/network boundary, not the unit here.
+// It is also where the add-on entitlement (`canUseBarcodes`) comes from, so
+// each test states it explicitly.
+vi.mock("~/utils/roles.server", () => ({
+  requirePermission: vi.fn(),
+}));
+vi.mock("~/utils/emitter/send-notification.server", () => ({
+  sendNotification: vi.fn(),
+}));
+
+import { updateAsset } from "~/modules/asset/service.server";
+import { requirePermission } from "~/utils/roles.server";
+
+/**
+ * Builds the action args for a plain save of the asset's core fields.
+ *
+ * why: happy-dom drops empty FormData fields on the Request round-trip, so the
+ * body is built as URLSearchParams (see the repo note on that behaviour).
+ */
+function buildArgs(fields: Record<string, string> = {}) {
+  const body = new URLSearchParams({
+    title: "An asset",
+    description: "",
+    category: "uncategorized",
+    ...fields,
+  });
+
+  const request = new Request("http://localhost/assets/asset-1/edit", {
+    method: "POST",
+    body,
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  });
+
+  return {
+    request,
+    params: { assetId: "asset-1" },
+    context: { getSession: () => ({ userId: "user-1" }) },
+  } as unknown as Parameters<typeof action>[0];
+}
+
+/** The single payload the action handed to `updateAsset`. */
+function updateAssetPayload() {
+  expect(updateAsset).toHaveBeenCalledTimes(1);
+  return vi.mocked(updateAsset).mock.calls[0][0];
+}
+
+describe("assets.$assetId_.edit — barcodes without the add-on", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(updateAsset).mockResolvedValue({
+      id: "asset-1",
+      title: "An asset",
+    } as never);
+  });
+
+  it("hands updateAsset no barcode list when the workspace lacks the add-on", async () => {
+    vi.mocked(requirePermission).mockResolvedValue({
+      organizationId: "org-1",
+      canUseBarcodes: false,
+    } as never);
+
+    await action(buildArgs());
+
+    const payload = updateAssetPayload();
+    expect(payload.barcodes).toBeUndefined();
+    expect(payload.preferredBarcodeId).toBeUndefined();
+  });
+
+  it("passes the submitted barcodes when the workspace has the add-on", async () => {
+    vi.mocked(requirePermission).mockResolvedValue({
+      organizationId: "org-1",
+      canUseBarcodes: true,
+    } as never);
+
+    await action(
+      buildArgs({
+        "barcodes[0].type": "Code128",
+        "barcodes[0].value": "ABC123",
+      })
+    );
+
+    expect(updateAssetPayload().barcodes).toEqual([
+      { type: "Code128", value: "ABC123" },
+    ]);
+  });
+});

--- a/apps/webapp/test/routes-tests/_layout+/kits.$kitId_.edit.barcodes-without-addon.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/kits.$kitId_.edit.barcodes-without-addon.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Kit edit route — barcodes are left alone when the workspace has no add-on.
+ *
+ * `updateKit` reconciles the barcode list it is given against the barcodes on
+ * the kit and deletes whatever is missing from that list. A workspace without
+ * the alternative-barcodes add-on submits no barcode fields at all (the form
+ * hides the section), so the action must hand `updateKit` no list rather than
+ * an empty one: barcode rows survive an add-on lapse and are back the moment
+ * the add-on is switched on again.
+ *
+ * @see {@link file://./../../../app/routes/_layout+/kits.$kitId_.edit.tsx}
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { action } from "~/routes/_layout+/kits.$kitId_.edit";
+
+// why: the route pulls the kit and asset service graphs (Prisma client,
+// Supabase storage, permissions); stubbing at the module boundary keeps this a
+// unit test of what the action hands to updateKit.
+vi.mock("~/modules/kit/service.server", () => ({
+  getKit: vi.fn().mockResolvedValue({ id: "kit-1", locationId: null }),
+  updateKit: vi.fn().mockResolvedValue({ id: "kit-1" }),
+  updateKitImage: vi.fn().mockResolvedValue(undefined),
+  updateKitLocation: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/modules/asset/service.server", () => ({
+  getCategoriesForCreateAndEdit: vi.fn(),
+  getLocationsForCreateAndEdit: vi.fn(),
+}));
+// why: permission resolution is an auth/network boundary, not the unit here.
+// It is also where the add-on entitlement (`canUseBarcodes`) comes from, so
+// each test states it explicitly.
+vi.mock("~/utils/roles.server", () => ({
+  requirePermission: vi.fn(),
+}));
+vi.mock("~/utils/emitter/send-notification.server", () => ({
+  sendNotification: vi.fn(),
+}));
+
+import { updateKit } from "~/modules/kit/service.server";
+import { requirePermission } from "~/utils/roles.server";
+
+/**
+ * Builds the action args for a plain save of the kit's core fields.
+ *
+ * why: happy-dom drops empty FormData fields on the Request round-trip, so the
+ * body is built as URLSearchParams (see the repo note on that behaviour).
+ */
+function buildArgs(fields: Record<string, string> = {}) {
+  const body = new URLSearchParams({
+    name: "A kit",
+    description: "",
+    ...fields,
+  });
+
+  const request = new Request("http://localhost/kits/kit-1/edit", {
+    method: "POST",
+    body,
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  });
+
+  return {
+    request,
+    params: { kitId: "kit-1" },
+    context: { getSession: () => ({ userId: "user-1" }) },
+  } as unknown as Parameters<typeof action>[0];
+}
+
+/** The single payload the action handed to `updateKit`. */
+function updateKitPayload() {
+  expect(updateKit).toHaveBeenCalledTimes(1);
+  return vi.mocked(updateKit).mock.calls[0][0];
+}
+
+describe("kits.$kitId_.edit — barcodes without the add-on", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(updateKit).mockResolvedValue({ id: "kit-1" } as never);
+  });
+
+  it("hands updateKit no barcode list when the workspace lacks the add-on", async () => {
+    vi.mocked(requirePermission).mockResolvedValue({
+      organizationId: "org-1",
+      canUseBarcodes: false,
+    } as never);
+
+    await action(buildArgs());
+
+    expect(updateKitPayload().barcodes).toBeUndefined();
+  });
+
+  it("passes the submitted barcodes when the workspace has the add-on", async () => {
+    vi.mocked(requirePermission).mockResolvedValue({
+      organizationId: "org-1",
+      canUseBarcodes: true,
+    } as never);
+
+    await action(
+      buildArgs({
+        "barcodes[0].type": "Code39",
+        "barcodes[0].value": "KIT001",
+      })
+    );
+
+    expect(updateKitPayload().barcodes).toEqual([
+      { type: "Code39", value: "KIT001" },
+    ]);
+  });
+});


### PR DESCRIPTION
## What this fixes

Two ways a lapsed add-on subscription misbehaved, found while tracing what happens when a workspace starts the 7-day Barcodes trial, adds its existing barcodes, and does not renew.

### 1. Editing an asset or kit deleted its barcodes once the add-on was gone

`assets.$assetId_.edit` and `kits.$kitId_.edit` handed `updateAsset` / `updateKit` an **empty** barcode list whenever the workspace lacked the alternative-barcodes add-on. Both services reconcile the list they are given against the stored barcodes and delete whatever is missing, so any ordinary edit (rename, category change, kit description) in a workspace whose trial or subscription had lapsed silently and permanently deleted every barcode on that asset or kit.

The trial emails promise the opposite ("your barcode data won't be deleted … everything will be right where you left it"), and the entitlement gate elsewhere is a freeze, not a delete: rows stay, they are hidden and unscannable, and they reappear when the add-on is active again.

The routes now pass `undefined`, which both services already treat as "barcodes not submitted". Present since the original barcode feature (July 2025); the self-serve trial made it reachable. Other update paths (overview quick actions, location update, mobile `asset.update`, CSV import) never passed a barcode list and are unaffected. Self-hosted deployments grant `canUseBarcodes` unconditionally and are unaffected.

### 2. Add-ons bundled on a Team subscription never switched off

A Team trial from the plan picker can carry Audits and Barcodes as extra line items on the **tier** subscription (`createTeamTrialSubscription`). Workspace creation links that subscription to the organization and switches the add-ons on, but `handleSubscriptionPaused` / `Updated` / `Deleted` only looked at the tier item: the user was downgraded while `auditsEnabled` / `barcodesEnabled` stayed on. `getDataFromStripeEvent` already computed `hasAuditAddon` / `hasBarcodeAddon`; no handler read them. Re-subscribing to Team without the add-ons, or dropping an add-on line item, kept the add-ons for free.

The tier branches now hand the event to the existing add-on handlers for every add-on present on the subscription (same pause/cancel/status semantics as a standalone add-on subscription), and an update whose `previous_attributes.items` included an add-on that is no longer on the subscription switches that add-on off. Transfer cancellations are skipped as before, and a subscription never linked to a workspace (`metadata.organizationId` absent) is left alone.

## Tests

- `test/routes-tests/_layout+/assets.$assetId_.edit.barcodes-without-addon.test.ts` and `kits.$kitId_.edit.barcodes-without-addon.test.ts`: the payload carries no barcode list without the add-on, and the submitted barcodes with it.
- `app/modules/stripe-webhook/handlers.server.test.ts` (new): bundled add-ons are paused / cancelled / status-synced with the tier subscription, tier-only and unlinked subscriptions are left alone, transfers are skipped, a removed add-on item is switched off, and a standalone add-on subscription still routes to its handler without touching the tier.

Locally: `pnpm webapp:test -- --run` (full suite), `tsc -b`, ESLint and Prettier on the changed files all pass.

## Notes for review

- No schema or migration changes.
- The enabling side is unchanged: bundled add-ons are still switched on by workspace creation (`linkAuditAddonToOrganization` / `linkBarcodeAddonToOrganization`) and by the `invoice.paid` safety net.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bundled Audits and Barcodes add-ons now follow the lifecycle of their tier subscription, including pauses, updates, and cancellations.
  * Removing a bundled add-on from a subscription automatically disables it.

* **Bug Fixes**
  * Editing assets or kits without the Barcodes add-on no longer removes existing barcode assignments. Existing barcodes are preserved unless explicitly changed.

* **Tests**
  * Added coverage for subscription add-on synchronization and barcode preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->