### PR TITLE
fix(companion): show who holds an asset through a booking on the asset screen

### DIFF
--- a/apps/companion/app/(tabs)/assets/[id].tsx
+++ b/apps/companion/app/(tabs)/assets/[id].tsx
@@ -39,6 +39,8 @@ import {
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
 import { useDateFormatter } from "@/lib/use-date-formatter";
+import { pushIntoTab } from "@/lib/navigation";
+import { buildBookingCustodyRows } from "@/lib/asset-custody-rows";
 import { TeamMemberPicker } from "@/components/team-member-picker";
 import { LocationPicker } from "@/components/location-picker";
 import { QuantityInputSheet } from "@/components/quantity-input-sheet";
@@ -101,7 +103,7 @@ export default function AssetDetailScreen() {
   const { colors, statusBadge } = useTheme();
   const styles = useStyles();
   // Render dates in the acting user's format preferences + timezone.
-  const { formatDate } = useDateFormatter();
+  const { formatDate, formatDateTime } = useDateFormatter();
 
   // Asset data
   const {
@@ -403,6 +405,15 @@ export default function AssetDetailScreen() {
     isQtyTracked && asset.custodyList && asset.custodyList.length > 0
       ? asset.custodyList
       : null;
+  // Custody held through a booking. Rendered only when neither custody source
+  // above has a row, the same precedence as the web asset page's card.
+  const bookingCustodyRows = buildBookingCustodyRows(asset.activeBooking, {
+    formatDateTime,
+    // The booking lives in another tab; the helper roots that tab at its list
+    // so "back" has somewhere to go.
+    onOpenBooking: (bookingId) =>
+      pushIntoTab("/(tabs)/bookings", `/(tabs)/bookings/${bookingId}`),
+  });
   // Cap for the assign-quantity step. Prefer the server's custodyAvailable
   // (web-parity cap that also excludes kit earmarks); fall back for older
   // servers to the broader `available`, then the plain total — the server
@@ -671,7 +682,18 @@ export default function AssetDetailScreen() {
                   value={formatDate(asset.custody.createdAt)}
                 />
               </>
-            ) : null}
+            ) : (
+              bookingCustodyRows.map((row) => (
+                <InfoRow
+                  key={row.key}
+                  icon={row.icon}
+                  label={row.label}
+                  value={row.value}
+                  onPress={row.onPress}
+                  accessibilityLabel={row.accessibilityLabel}
+                />
+              ))
+            )}
             {/* Holders hidden from this caller (privacy filtering) — one calm
                 muted row so partial lists don't read as the full picture. */}
             {custodyOthersCount > 0 && (

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -243,6 +243,26 @@ export type AssetDetail = {
       } | null;
     };
   } | null;
+  /**
+   * The booking an INDIVIDUAL asset is checked out on, and who holds the asset
+   * through it: the web asset page's "In custody of … via …" card. Everything
+   * is resolved server-side, so the screen prints it and derives nothing.
+   *
+   * - `from`: the booking's start, an ISO instant.
+   * - `custodianName`: `null` when the booking has no custodian.
+   * - `canOpen`: whether this viewer may open the booking. The row is only
+   *   tappable when true; the booking screen refuses everyone else.
+   *
+   * `null` when the asset is not checked out, is quantity-tracked, or the
+   * viewer may not see custody. Absent on older servers — render nothing.
+   */
+  activeBooking?: {
+    id: string;
+    name: string;
+    from: string;
+    custodianName: string | null;
+    canOpen: boolean;
+  } | null;
   kit: { id: string; name: string; status: string } | null;
   tags: { id: string; name: string }[];
   qrCodes: { id: string }[];

--- a/apps/companion/lib/asset-custody-rows.test.ts
+++ b/apps/companion/lib/asset-custody-rows.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for the asset detail screen's "custody through a booking" rows.
+ *
+ * These run under Node's test runner via tsx, so this file and the module it
+ * tests must not import React Native, Expo, or `@/`-aliased paths.
+ *
+ * The fixture has the shape the detail endpoint sends as `activeBooking`; the
+ * webapp's route test pins the same shape from the producer side.
+ *
+ * @see ./asset-custody-rows.ts
+ * @see ../../webapp/test/routes-tests/api+/mobile.assets.assetId.test.ts
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildBookingCustodyRows,
+  type CustodyInfoRow,
+} from "./asset-custody-rows";
+import type { AssetDetail } from "./api/types";
+
+type ActiveBooking = NonNullable<AssetDetail["activeBooking"]>;
+
+/** The detail endpoint's `activeBooking`, as it arrives over the wire. */
+function activeBooking(overrides: Partial<ActiveBooking> = {}): ActiveBooking {
+  return {
+    id: "booking-1",
+    name: "Field shoot",
+    from: "2026-03-02T09:30:00.000Z",
+    custodianName: "Caz",
+    canOpen: true,
+    ...overrides,
+  };
+}
+
+/**
+ * Builds the rows with a stand-in date formatter, recording every booking the
+ * rows open.
+ */
+function build(input: AssetDetail["activeBooking"]) {
+  const opened: string[] = [];
+  const rows = buildBookingCustodyRows(input, {
+    formatDateTime: (iso) => `at ${iso}`,
+    onOpenBooking: (bookingId) => {
+      opened.push(bookingId);
+    },
+  });
+  return { rows, opened };
+}
+
+/** A row with its press handler reduced to whether it has one. */
+function withoutHandler({ onPress, ...row }: CustodyInfoRow) {
+  return { ...row, tappable: onPress !== undefined };
+}
+
+test("shows who holds the asset, through which booking, and since when", () => {
+  const { rows, opened } = build(activeBooking());
+
+  assert.deepEqual(rows.map(withoutHandler), [
+    {
+      key: "booking-custodian",
+      icon: "person-outline",
+      label: "In Custody Of",
+      value: "Caz",
+      tappable: false,
+    },
+    {
+      key: "booking",
+      icon: "calendar-outline",
+      label: "Via Booking",
+      value: "Field shoot",
+      accessibilityLabel: "View booking Field shoot",
+      tappable: true,
+    },
+    {
+      key: "booking-since",
+      icon: "time-outline",
+      label: "Since",
+      value: "at 2026-03-02T09:30:00.000Z",
+      tappable: false,
+    },
+  ]);
+
+  rows[1]?.onPress?.();
+  assert.deepEqual(opened, ["booking-1"]);
+});
+
+test("omits the holder row when the booking has no custodian", () => {
+  const { rows } = build(activeBooking({ custodianName: null }));
+
+  assert.deepEqual(
+    rows.map((row) => row.label),
+    ["Via Booking", "Since"]
+  );
+});
+
+test("gives the booking row no press handler when the viewer may not open it", () => {
+  const { rows } = build(activeBooking({ canOpen: false }));
+  const bookingRow = rows.find((row) => row.label === "Via Booking");
+
+  assert.ok(bookingRow);
+  assert.equal(bookingRow.value, "Field shoot");
+  assert.equal(bookingRow.onPress, undefined);
+  assert.equal(bookingRow.accessibilityLabel, undefined);
+  // The other rows still render
+  assert.deepEqual(
+    rows.map((row) => row.label),
+    ["In Custody Of", "Via Booking", "Since"]
+  );
+});
+
+test("renders no rows when the server sends no booking", () => {
+  assert.deepEqual(build(null).rows, []);
+});
+
+test("renders no rows when a server too old to send the field omits it", () => {
+  assert.deepEqual(build(undefined).rows, []);
+});

--- a/apps/companion/lib/asset-custody-rows.ts
+++ b/apps/companion/lib/asset-custody-rows.ts
@@ -1,0 +1,101 @@
+/**
+ * Custody rows for an asset held through a booking.
+ *
+ * For an INDIVIDUAL asset that is checked out on a booking, the asset detail
+ * endpoint sends `activeBooking`: the booking, who holds the asset through it,
+ * and whether this viewer may open it. This module lays that out as the
+ * label/value rows the detail screen renders, the phone's form of the web
+ * asset page's "In custody of {name} via {booking} Since {date}" card.
+ *
+ * Not a mirror of webapp logic: which booking, who may see it and who may
+ * open it are all decided by the server. This module only decides which rows
+ * exist and which one is tappable. It is pure and free of React Native, Expo
+ * and `@/` paths so it runs under Node's test runner; the screen owns the
+ * pixels and the navigation.
+ *
+ * @see {@link file://./asset-custody-rows.test.ts}
+ * @see {@link file://../app/(tabs)/assets/[id].tsx} the only consumer
+ * @see ../../webapp/app/routes/api+/mobile+/assets.$assetId.ts — the producer
+ * @see ../../webapp/app/components/assets/asset-custody-card.tsx — the web card
+ */
+import type { AssetDetail } from "./api/types";
+
+/** One label/value row on the asset detail screen: `InfoRow`'s props plus a key. */
+export type CustodyInfoRow = {
+  /** Stable React key for the row. */
+  key: string;
+  /** Ionicons glyph shown beside the label. */
+  icon: string;
+  /** The field label. */
+  label: string;
+  /** The field value. */
+  value: string;
+  /** Present only on a row the viewer may tap. */
+  onPress?: () => void;
+  /** A11y label, present only on a row the viewer may tap. */
+  accessibilityLabel?: string;
+};
+
+/**
+ * Builds the "custody through a booking" rows for the asset detail screen.
+ *
+ * Up to three rows, in order: who holds the asset, the booking, and since
+ * when. The holder row is left out when the booking has no custodian. The
+ * booking row opens the booking only when the server says this viewer may:
+ * the booking screen refuses everyone else, so offering the tap to them would
+ * end in an error.
+ *
+ * @param activeBooking - The detail endpoint's `activeBooking`, as received:
+ *   `null` when there is nothing to show, absent on older servers
+ * @param options.formatDateTime - Formats an ISO instant as date and time in
+ *   the viewer's preferences
+ * @param options.onOpenBooking - Opens the booking with the given id
+ * @returns The rows to render, in order; empty when there is no booking
+ */
+export function buildBookingCustodyRows(
+  activeBooking: AssetDetail["activeBooking"],
+  {
+    formatDateTime,
+    onOpenBooking,
+  }: {
+    formatDateTime: (iso: string) => string;
+    onOpenBooking: (bookingId: string) => void;
+  }
+): CustodyInfoRow[] {
+  // Truthiness, not a shape check: an older server omits the field entirely.
+  if (!activeBooking) return [];
+
+  const { id, name, from, custodianName, canOpen } = activeBooking;
+  const rows: CustodyInfoRow[] = [];
+
+  if (custodianName) {
+    rows.push({
+      key: "booking-custodian",
+      icon: "person-outline",
+      label: "In Custody Of",
+      value: custodianName,
+    });
+  }
+
+  rows.push({
+    key: "booking",
+    icon: "calendar-outline",
+    label: "Via Booking",
+    value: name,
+    ...(canOpen
+      ? {
+          onPress: () => onOpenBooking(id),
+          accessibilityLabel: `View booking ${name}`,
+        }
+      : {}),
+  });
+
+  rows.push({
+    key: "booking-since",
+    icon: "time-outline",
+    label: "Since",
+    value: formatDateTime(from),
+  });
+
+  return rows;
+}

--- a/apps/webapp/app/routes/api+/mobile+/assets.$assetId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/assets.$assetId.ts
@@ -1,3 +1,4 @@
+import { AssetStatus } from "@prisma/client";
 import { data, type LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
 import { getQuantityData } from "~/components/assets/asset-status-badge/quantity-data";
@@ -16,13 +17,22 @@ import { serializeImageExpiration } from "~/modules/asset/image-resolution";
 import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
 import { getAssetQuantityRows } from "~/modules/asset/quantity-breakdown.server";
 import { isQuantityTracked } from "~/modules/asset/utils";
+import { USER_NAME_SELECT } from "~/modules/user/fields";
+import { canSeeBooking } from "~/utils/booking-authorization.server";
 import { makeShelfError } from "~/utils/error";
 import { getParams } from "~/utils/http.server";
+import {
+  resolveTeamMemberName,
+  resolveUserDisplayName,
+  type UserNameFields,
+} from "~/utils/user";
 
 /**
  * GET /api/mobile/assets/:assetId
  *
  * Returns full asset details including category, location, custody, and kit.
+ * For an INDIVIDUAL asset checked out on a booking, `activeBooking` names that
+ * booking and who holds the asset through it.
  *
  * Image URLs are returned as-stored along with `mainImageExpiration`. Mobile
  * clients should call `/api/mobile/asset/refresh-image/:assetId` lazily when
@@ -36,9 +46,11 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
     // Custody visibility is permission-gated (web parity): viewers without
     // custody-view permission (SELF_SERVICE/BASE, unless the org overrides
-    // allow) must not receive other holders' custody. Resolve the flag once
-    // here; the filtering happens below, after shaping.
-    const { canSeeAllCustody } = await getMobileUserContext(
+    // allow) must not receive other holders' custody. Resolve the flags once
+    // here; the filtering happens below, after shaping. `canSeeAllBookings`
+    // is the booking screen's own read gate, which `activeBooking.canOpen`
+    // answers in advance.
+    const { canSeeAllCustody, canSeeAllBookings } = await getMobileUserContext(
       user.id,
       organizationId
     );
@@ -56,15 +68,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         description: true,
         status: true,
         mainImage: true,
-        // The web asset overview shows "Asset ID SAM-0017"; the companion
-        // scanner even invites you to type a SAM ID ("Enter QR, barcode, or
-        // SAM ID"), but no mobile screen could show you one because this
-        // payload never carried it.
+        // The workspace-scoped "SAM-0017" ID. The detail screen shows it, as
+        // the web asset overview does, because the scanner's manual entry
+        // accepts it ("Enter QR, barcode, or SAM ID").
         sequentialId: true,
         /**
-         * `name` drives the detail screen's Model row, which web has always
-         * shown and mobile never did; the image columns feed the shaper's
-         * cover-image cascade.
+         * `name` drives the detail screen's Model row, as on the web asset
+         * overview; the image columns feed the shaper's cover-image cascade.
          *
          * Merged into ONE key with a spread of the shared constant rather than
          * re-listing the image columns — same reasoning as
@@ -124,7 +134,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
                 // why: powers the server-side custody-visibility filter below
                 // ("is this row the caller's own?"). Also web parity: the web
                 // asset page ships custodian.userId to the client
-                // (asset-custody-card.tsx:87 reads it) — additive here.
+                // (`CustodyCard` links the custodian's profile with it).
                 userId: true,
                 user: {
                   select: {
@@ -142,6 +152,33 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         assetKits: {
           select: {
             kit: { select: { id: true, name: true, status: true } },
+          },
+        },
+        // The active booking the asset is out on. Same filter as the web
+        // asset overview (`getAssetOverviewFields`): ONGOING or OVERDUE, and
+        // not partially checked in for this asset. Read only to build
+        // `activeBooking` below; the rows themselves never reach the client.
+        bookingAssets: {
+          where: {
+            booking: {
+              status: { in: ["ONGOING", "OVERDUE"] },
+              NOT: {
+                partialCheckins: { some: { assetIds: { has: assetId } } },
+              },
+            },
+          },
+          select: {
+            booking: {
+              select: {
+                id: true,
+                name: true,
+                from: true,
+                custodianTeamMember: {
+                  select: { id: true, name: true, userId: true },
+                },
+                custodianUser: { select: { id: true, ...USER_NAME_SELECT } },
+              },
+            },
           },
         },
         tags: { select: { id: true, name: true } },
@@ -211,7 +248,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       availableToBook: asset.availableToBook,
       // Helper's `category` type is `{ name } | null`; widen-then-narrow.
       category: asset.category ? { name: asset.category.name } : null,
-      // Quantity scalars the helper now requires (this route only consumes
+      // Quantity scalars the helper requires (this route only consumes
       // the helper's flattened kit/location below, but the param type must
       // be satisfied).
       type: asset.type,
@@ -290,6 +327,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       assetModel: detailAssetModel,
       custody: detailCustody,
       category: detailCategory,
+      // Read into `activeBooking` below; the raw rows stay on the server.
+      bookingAssets: _bookingAssets,
       ...assetData
     } = asset;
 
@@ -304,8 +343,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     // Custody visibility parity (server-side, since mobile clients are
     // untrusted): when the caller lacks custody-view permission, filter
     // `custodyList` to their OWN entries and report how many holders were
-    // hidden — mirroring the web's QuantityCustodyList filter + hidden-count
-    // (quantity-custody-list.tsx:121-126).
+    // hidden — mirroring the web's `QuantityCustodyList` filter and hidden
+    // count (its `canViewAllCustody` prop).
     const { custodyList, custodyListOthersCount } =
       filterMobileCustodyListForViewer({
         custodyList: flattened.custodyList,
@@ -316,9 +355,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
     // Legacy single `custody`: the web HIDES its single-custodian card from
     // viewers without custody-view permission unless they ARE the custodian —
-    // assets.$assetId.overview.tsx:1826-1836 passes
+    // assets.$assetId.overview.tsx:1757-1769 passes
     // hasPermission={userCanViewSpecificCustody(...)} and CustodyCard renders
-    // nothing when !hasPermission (asset-custody-card.tsx:63). Mirror that
+    // nothing when !hasPermission (asset-custody-card.tsx:66-68). Mirror that
     // exactly: null the field when the caller may not see it.
     const primaryCustody = detailCustody[0] ?? null;
     const visibleCustody =
@@ -330,6 +369,47 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       })
         ? primaryCustody
         : null;
+
+    // Custody held through a booking, for an asset checked out on one. A
+    // booking checkout writes no Custody row, so this is the only way the
+    // detail screen can say who has the asset. It follows the web asset
+    // overview's CustodyCard on every point:
+    // - the asset must be CHECKED_OUT. Assets added to an ONGOING booking stay
+    //   AVAILABLE until they are checked out, and the web shows no card then;
+    // - the `bookingAssets` select above decides which booking, and the first
+    //   row wins, as it does on the web;
+    // - INDIVIDUAL assets only. A quantity-tracked asset's custody is its
+    //   quantity breakdown;
+    // - only viewers who may see all custody. The web's "is it yours" check
+    //   reads the custody row's user, which a booking checkout does not write,
+    //   so a booking's own custodian without that permission sees no card.
+    const checkedOutOn =
+      !isQuantityTracked(asset) &&
+      asset.status === AssetStatus.CHECKED_OUT &&
+      canSeeAllCustody
+        ? asset.bookingAssets[0]?.booking ?? null
+        : null;
+
+    const activeBooking = checkedOutOn
+      ? {
+          id: checkedOutOn.id,
+          name: checkedOutOn.name,
+          from: checkedOutOn.from,
+          custodianName: resolveBookingHolderName(checkedOutOn),
+          // Seeing custody and seeing bookings are separate workspace
+          // overrides, so a viewer shown this booking may still be refused by
+          // the booking screen. This is that screen's own gate, answered here
+          // so the app only offers a tap that will open.
+          canOpen: canSeeBooking({
+            canSeeAllBookings,
+            booking: {
+              custodianUserId: checkedOutOn.custodianUser?.id ?? null,
+              custodianTeamMember: checkedOutOn.custodianTeamMember,
+            },
+            userId: user.id,
+          }),
+        }
+      : null;
 
     return data({
       asset: {
@@ -372,6 +452,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         // Additive: number of holders hidden from this caller (0 when the
         // caller can see all custody) so the app can render "+N others".
         custodyListOthersCount,
+        // Additive: the booking an INDIVIDUAL asset is checked out on and who
+        // holds it through that booking; null otherwise (see above).
+        activeBooking,
         // why: re-attach the wider category shape (id + color) the detail
         // endpoint loads — the helper only types {name}.
         category: detailCategory,
@@ -388,4 +471,29 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       { status: reason.status }
     );
   }
+}
+
+/**
+ * The name of whoever holds a booking, resolved the way the web asset
+ * overview's `CustodyCard` resolves it: the custodian user's display name when
+ * the booking has a user custodian, otherwise the custodian team member's
+ * name.
+ *
+ * @param booking - The booking's two custody links
+ * @returns The name, or `null` when the booking has no custodian or the
+ *   custodian's name is empty
+ */
+function resolveBookingHolderName(booking: {
+  custodianUser: UserNameFields | null;
+  custodianTeamMember: { name: string } | null;
+}): string | null {
+  if (booking.custodianUser) {
+    return resolveUserDisplayName(booking.custodianUser) || null;
+  }
+  if (booking.custodianTeamMember) {
+    return (
+      resolveTeamMemberName({ name: booking.custodianTeamMember.name }) || null
+    );
+  }
+  return null;
 }

--- a/apps/webapp/test/routes-tests/api+/mobile.assets.assetId.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.assets.assetId.test.ts
@@ -1,17 +1,23 @@
 /**
- * Test suite for GET /api/mobile/assets/:assetId — custody visibility.
+ * Test suite for GET /api/mobile/assets/:assetId.
  *
- * Pins the server-side custody-visibility parity fix: viewers without
- * custody-view permission (SELF_SERVICE/BASE without the org override) must
- * only receive their OWN `custodyList` entries plus a hidden-holders count
- * (`custodyListOthersCount`), and the legacy single `custody` field is
- * nulled unless the viewer can see all custody or IS the primary custodian —
- * mirroring the web (quantity-custody-list.tsx:121-126 and
- * assets.$assetId.overview.tsx:1826-1836 + asset-custody-card.tsx:63).
+ * Pins what the companion's asset detail screen may be sent:
  *
- * The filtering helpers from `mobile-custody-visibility.server` are NOT
- * mocked, so the real visibility logic is exercised end to end through the
- * loader.
+ * - Custody visibility. Viewers without custody-view permission
+ *   (SELF_SERVICE/BASE without the org override) receive only their OWN
+ *   `custodyList` entries plus a hidden-holders count
+ *   (`custodyListOthersCount`), and the legacy single `custody` field is null
+ *   unless the viewer can see all custody or IS the primary custodian. The web
+ *   behaves the same way: `QuantityCustodyList` filters and counts its rows,
+ *   and the asset overview hides `CustodyCard` through its `hasPermission`.
+ * - Custody through a booking. `activeBooking` names the booking an INDIVIDUAL
+ *   asset is checked out on, picked and gated the way the web asset overview
+ *   picks the booking its `CustodyCard` shows.
+ * - The projection. Rows destructured off the query result stay off the wire.
+ *
+ * The visibility helpers from `mobile-custody-visibility.server`, the booking
+ * read gate and the name resolvers are NOT mocked, so the real logic runs end
+ * to end through the loader.
  *
  * @see {@link file://../../../app/routes/api+/mobile+/assets.$assetId.ts}
  */
@@ -196,11 +202,70 @@ function buildAsset() {
       },
     ],
     assetKits: [],
+    // Active booking rows; none for this asset
+    bookingAssets: [],
     tags: [],
     qrCodes: [],
     organization: { currency: "USD" },
     notes: [],
     customFields: [],
+  };
+}
+
+/** The booking custody links a fixture booking may override. */
+type BookingCustodianOverrides = {
+  custodianTeamMember?: {
+    id: string;
+    name: string;
+    userId: string | null;
+  } | null;
+  custodianUser?: {
+    id: string;
+    firstName: string | null;
+    lastName: string | null;
+    displayName: string | null;
+  } | null;
+};
+
+/**
+ * An INDIVIDUAL asset checked out on an ONGOING booking. A booking checkout
+ * writes no Custody row, so `custody` is empty and the holder is known only
+ * through the booking. The default custodian is a registered user whose
+ * display name, team-member name and legal name all differ, so an assertion
+ * can tell which one the response used.
+ *
+ * @param booking - Overrides for the booking's custody links
+ */
+function buildCheckedOutAsset(booking: BookingCustodianOverrides = {}) {
+  return {
+    ...buildAsset(),
+    title: "Camera A",
+    status: "CHECKED_OUT",
+    type: "INDIVIDUAL",
+    quantity: null,
+    unitOfMeasure: null,
+    custody: [],
+    bookingAssets: [
+      {
+        booking: {
+          id: "booking-1",
+          name: "Field shoot",
+          from: new Date("2026-03-02T09:30:00Z"),
+          custodianTeamMember: {
+            id: "tm-carol",
+            name: "Carol Member",
+            userId: "user-7",
+          },
+          custodianUser: {
+            id: "user-7",
+            firstName: "Carol",
+            lastName: "Legal",
+            displayName: "Caz",
+          },
+          ...booking,
+        },
+      },
+    ],
   };
 }
 
@@ -229,6 +294,7 @@ describe("GET /api/mobile/assets/:assetId — custody visibility", () => {
       canUseBarcodes: false,
       canUseAudits: false,
       canSeeAllCustody: true,
+      canSeeAllBookings: true,
     });
 
     (db.asset.findUnique as any).mockResolvedValue(buildAsset());
@@ -240,6 +306,7 @@ describe("GET /api/mobile/assets/:assetId — custody visibility", () => {
       canUseBarcodes: false,
       canUseAudits: false,
       canSeeAllCustody: false,
+      canSeeAllBookings: false,
     });
 
     const result = await loader(
@@ -276,6 +343,7 @@ describe("GET /api/mobile/assets/:assetId — custody visibility", () => {
       canUseBarcodes: false,
       canUseAudits: false,
       canSeeAllCustody: false,
+      canSeeAllBookings: false,
     });
     // Reorder so the caller's row is the primary (oldest) one
     const asset = buildAsset();
@@ -340,6 +408,7 @@ describe("GET /api/mobile/assets/:assetId — payload projection", () => {
       canUseBarcodes: false,
       canUseAudits: false,
       canSeeAllCustody: true,
+      canSeeAllBookings: true,
     });
     (db.asset.findUnique as any).mockResolvedValue(buildAsset());
   });
@@ -390,4 +459,233 @@ describe("GET /api/mobile/assets/:assetId — payload projection", () => {
 
     expect(body.asset.assetModel).toBeNull();
   });
+});
+
+/**
+ * `activeBooking` follows the web asset overview's `CustodyCard` for custody
+ * held through a booking: the same gate (the asset is CHECKED_OUT), the same
+ * booking (the `bookingAssets` filter, first row), the same visibility (the
+ * viewer may see all custody), and INDIVIDUAL assets only.
+ */
+describe("GET /api/mobile/assets/:assetId — custody through a booking", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+
+    (requireMobileAuth as any).mockResolvedValue({
+      user: mockUser,
+      authUser: { id: "auth-user-1", email: mockUser.email },
+    });
+    (requireOrganizationAccess as any).mockResolvedValue("org-1");
+    (getMobileUserContext as any).mockResolvedValue({
+      role: "ADMIN",
+      canUseBarcodes: false,
+      canUseAudits: false,
+      canSeeAllCustody: true,
+      canSeeAllBookings: true,
+    });
+    (db.asset.findUnique as any).mockResolvedValue(buildCheckedOutAsset());
+  });
+
+  /** Runs the loader for `asset-1` and returns the parsed body. */
+  async function loadDetail() {
+    const result = await loader(
+      createLoaderArgs({
+        request: createDetailRequest(),
+        params: { assetId: "asset-1" },
+      })
+    );
+    expect((result as unknown as Response).status).toBe(200);
+    return (result as unknown as Response).json();
+  }
+
+  /**
+   * Signs the caller in as a SELF_SERVICE member whose workspace grants the
+   * given overrides.
+   */
+  function asSelfServiceViewer(overrides: {
+    canSeeAllCustody: boolean;
+    canSeeAllBookings: boolean;
+  }) {
+    (getMobileUserContext as any).mockResolvedValue({
+      role: "SELF_SERVICE",
+      canUseBarcodes: false,
+      canUseAudits: false,
+      ...overrides,
+    });
+  }
+
+  it("names the booking and its holder for a viewer who may see all custody", async () => {
+    const body = await loadDetail();
+
+    expect(body.asset.activeBooking).toEqual({
+      id: "booking-1",
+      name: "Field shoot",
+      from: "2026-03-02T09:30:00.000Z",
+      // The user's display name: the web card resolves the user link first
+      custodianName: "Caz",
+      canOpen: true,
+    });
+    // The raw rows only feed the field above
+    expect(body.asset).not.toHaveProperty("bookingAssets");
+  });
+
+  it("names a team-member custodian that has no user account", async () => {
+    (db.asset.findUnique as any).mockResolvedValue(
+      buildCheckedOutAsset({
+        custodianUser: null,
+        custodianTeamMember: {
+          id: "tm-dana",
+          name: "Dana Contractor",
+          userId: null,
+        },
+      })
+    );
+
+    const body = await loadDetail();
+
+    expect(body.asset.activeBooking.custodianName).toBe("Dana Contractor");
+  });
+
+  it("sends a null custodian name when the booking has no custodian", async () => {
+    (db.asset.findUnique as any).mockResolvedValue(
+      buildCheckedOutAsset({ custodianUser: null, custodianTeamMember: null })
+    );
+
+    const body = await loadDetail();
+
+    expect(body.asset.activeBooking.id).toBe("booking-1");
+    expect(body.asset.activeBooking.custodianName).toBeNull();
+  });
+
+  it("withholds the booking from a viewer who may not see custody", async () => {
+    asSelfServiceViewer({ canSeeAllCustody: false, canSeeAllBookings: false });
+
+    const body = await loadDetail();
+
+    expect(body.asset.activeBooking).toBeNull();
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain("Field shoot");
+    expect(serialized).not.toContain("Caz");
+    expect(serialized).not.toContain("Carol");
+  });
+
+  it("withholds it from the booking's own custodian as well, like the web card", async () => {
+    asSelfServiceViewer({ canSeeAllCustody: false, canSeeAllBookings: false });
+    (db.asset.findUnique as any).mockResolvedValue(
+      buildCheckedOutAsset({
+        custodianTeamMember: {
+          id: "tm-me",
+          name: "Test User",
+          userId: "user-1",
+        },
+        custodianUser: {
+          id: "user-1",
+          firstName: "Test",
+          lastName: "User",
+          displayName: null,
+        },
+      })
+    );
+
+    const body = await loadDetail();
+
+    // The web card's "is it yours" check reads the CUSTODY row's user, and a
+    // booking checkout writes no custody row, so only the permission counts.
+    expect(body.asset.activeBooking).toBeNull();
+  });
+
+  it("ignores booking rows on a quantity-tracked asset", async () => {
+    (db.asset.findUnique as any).mockResolvedValue({
+      ...buildAsset(),
+      status: "CHECKED_OUT",
+      bookingAssets: buildCheckedOutAsset().bookingAssets,
+    });
+
+    const body = await loadDetail();
+
+    expect(body.asset.activeBooking).toBeNull();
+    // Its custody is the quantity breakdown, which still arrives
+    expect(body.asset.quantityBreakdown).not.toBeNull();
+    expect(body.asset).not.toHaveProperty("bookingAssets");
+  });
+
+  it("sends null, and no raw rows, when the asset is on no active booking", async () => {
+    (db.asset.findUnique as any).mockResolvedValue({
+      ...buildCheckedOutAsset(),
+      bookingAssets: [],
+    });
+
+    const body = await loadDetail();
+
+    expect(body.asset.activeBooking).toBeNull();
+    expect(body.asset).not.toHaveProperty("bookingAssets");
+  });
+
+  it("sends null for an asset staged onto an ongoing booking but not checked out", async () => {
+    (db.asset.findUnique as any).mockResolvedValue({
+      ...buildCheckedOutAsset(),
+      // Assets added to an ONGOING booking stay AVAILABLE until checked out
+      status: "AVAILABLE",
+    });
+
+    const body = await loadDetail();
+
+    expect(body.asset.activeBooking).toBeNull();
+  });
+
+  it("shows the booking as closed to a viewer who may see custody but not other people's bookings", async () => {
+    asSelfServiceViewer({ canSeeAllCustody: true, canSeeAllBookings: false });
+
+    const body = await loadDetail();
+
+    expect(body.asset.activeBooking).toEqual({
+      id: "booking-1",
+      name: "Field shoot",
+      from: "2026-03-02T09:30:00.000Z",
+      custodianName: "Caz",
+      canOpen: false,
+    });
+  });
+
+  it.each([
+    [
+      "user link",
+      {
+        custodianTeamMember: {
+          id: "tm-me",
+          name: "Test User",
+          userId: null,
+        },
+        custodianUser: {
+          id: "user-1",
+          firstName: "Test",
+          lastName: "User",
+          displayName: null,
+        },
+      },
+    ],
+    [
+      "team-member link",
+      {
+        custodianTeamMember: {
+          id: "tm-me",
+          name: "Test User",
+          userId: "user-1",
+        },
+        custodianUser: null,
+      },
+    ],
+  ] satisfies [string, BookingCustodianOverrides][])(
+    "lets the booking's custodian open it through the %s",
+    async (_link, booking) => {
+      asSelfServiceViewer({ canSeeAllCustody: true, canSeeAllBookings: false });
+      (db.asset.findUnique as any).mockResolvedValue(
+        buildCheckedOutAsset(booking)
+      );
+
+      const body = await loadDetail();
+
+      expect(body.asset.activeBooking.canOpen).toBe(true);
+    }
+  );
 });


### PR DESCRIPTION
## What

The web asset page shows "In custody of {name} via {booking} Since {date}" for an asset that is checked out on a booking. The phone's asset screen showed only the "Checked out" badge: a booking checkout writes no `Custody` row, and the mobile asset endpoint sent no booking, so the app had no holder to show.

- **Server:** `GET /api/mobile/assets/:assetId` gains an additive field, `activeBooking: { id, name, from, custodianName, canOpen } | null`. Everything is resolved on the server; the app prints it.
- **App:** the asset screen renders it as three rows: "In Custody Of", "Via Booking" (opens the booking) and "Since" (date and time). They come after the two existing custody sources, which is the web card's precedence.

## Rules, copied from the web card

- **Gate:** the asset must be `CHECKED_OUT`. Assets added to an ONGOING booking stay AVAILABLE until they are checked out, and the web shows no card for them.
- **Which booking:** the same `bookingAssets` filter as `getAssetOverviewFields`: ONGOING or OVERDUE, and not partially checked in for this asset. The first row wins with no `orderBy`. That is parity with the web, which takes the first row of the same query, not a uniqueness claim.
- **INDIVIDUAL assets only.** A quantity-tracked asset's custody is its quantity breakdown, which is unchanged.
- **Visibility:** `activeBooking` is set only when the viewer can see all custody (`canSeeAllCustody`). The web card's `userCanViewSpecificCustody` receives the custody row's user, and a booking checkout writes no custody row, so only the permission counts there too.
- **Holder name:** the custodian user's display name, else the custodian team member's name, as the web card resolves it.
- **`canOpen`:** custody visibility and booking visibility are separate workspace overrides, so a viewer shown the rows may still be refused by the booking screen. `canOpen` is that screen's own gate (`canSeeBooking` with `canSeeAllBookings`), and the booking row is tappable only when it is true.
- The raw `bookingAssets` rows are stripped before the response.

## Notes for reviewers

- **Per-slice markers:** the kit page reads `BookingAsset.checkedOutAt`/`checkedInAt`, but the asset page still uses the `partialCheckins` filter above. This PR mirrors the asset page on purpose; moving both surfaces to the slice markers is a follow-up.
- **Visibility is not widened:** a booking's own custodian without the custody-view permission does not see these rows, exactly like the web card. Widening that (the server's `ownsBooking` rule in `utils/custody-visibility.server.ts`) is a product change and not part of this PR.
- **Scope:** only the asset detail screen, mirroring the web asset page's card. The asset list, the scanner result sheet and the kit screen are unchanged.
- **Relation to #2870** (bookings list on the asset screen): both PRs touch `app/(tabs)/assets/[id].tsx` and `lib/api/types.ts`; whichever merges second rebases. #2870's list row derives the holder's name on the phone (team-member name first, no display name). When it rebases it should print the server-resolved `custodianName` introduced here, so the holder does not appear twice with two spellings.
- Comment-only: the endpoint file's stale source references and history-narrating comments are rewritten.

## Ship path

- No migration.
- Server half: live on deploy. Older app builds ignore the new field.
- App half: needs an OTA publish (`eas update`) after the deploy. The app downloads the fix on the first open and runs it from the second open. Pre-publish gate: `check-bundle-env.mjs` (no QA strings in the bundle).
- A new app build talking to an older server receives no field and renders nothing.

## Tests

- **Server** (`test/routes-tests/api+/mobile.assets.assetId.test.ts`, failing before the change): user custodian resolved to the display name; team-member custodian; booking without a custodian; restricted viewer who is not the custodian; restricted viewer who is the custodian; quantity-tracked asset ignored; no active booking and no raw rows on the wire; asset staged but not checked out; `canOpen: false` without the bookings override; `canOpen: true` for the custodian through either custody link.
- **App** (`lib/asset-custody-rows.test.ts`, `node --test`): full row set; no custodian omits the holder row; `canOpen: false` gives no press handler; `null` and an absent field give no rows.
- `pnpm webapp:validate`, companion `test`/`typecheck`/`lint`, and react-doctor in diff mode for both apps.

## Verified on the simulator against a local server (QA data, deleted afterwards)

- Owner, individual asset checked out with the web "Check out" button on a booking whose custodian is a team member: the phone shows "In Custody Of", "Via Booking" and "Since" (date and time), and tapping "Via Booking" opens that booking. The web asset page's card shows the same name, booking and moment.
- Self-service member who is not the custodian, with both workspace overrides off: no rows, and the screen renders normally.
- Quantity-tracked asset checked out on the same booking: no booking rows; the quantity block is unchanged.
- Asset added to the ongoing booking but not checked out (still Available): no rows.
- The same asset after it is checked in on its own, with the booking still ongoing: the rows are gone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asset details now show custody information from active bookings, including the custodian, booking name, and checkout date.
  * When permitted, users can open the associated booking directly from the asset screen.
  * Booking visibility and access are tailored to the viewer’s permissions.

* **Bug Fixes**
  * Improved custody details for checked-out individual assets, including accurate custodian names and booking access.
  * Preserved compatibility when booking information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->