### PR TITLE
feat(companion): select kits as one unit in booking modes

### DIFF
--- a/apps/companion/.maestro/flows/bookings/07-create-add-reserve-edit-remove.yaml
+++ b/apps/companion/.maestro/flows/bookings/07-create-add-reserve-edit-remove.yaml
@@ -20,7 +20,9 @@ tags:
     visible: ".*Current workspace.*"
     timeout: 8000
 - tapOn: ".*Current workspace.*"
-- tapOn: "GRANULAR WORKSPACE"
+# The picker renders the active workspace as "NAME (current)", so a bare name
+# misses when the session already sits in it.
+- tapOn: "GRANULAR WORKSPACE.*"
 - waitForAnimationToEnd
 
 # ── Create a DRAFT ──
@@ -116,9 +118,9 @@ tags:
 - tapOn: "Select assets to remove"
 - tapOn: ".*3B Scientific.*"
 - extendedWaitUntil:
-    visible: ".*Remove 1 selected.*"
+    visible: "Remove 1 Asset"
     timeout: 10000
-- tapOn: ".*Remove 1 selected.*"
+- tapOn: "Remove 1 Asset"
 - extendedWaitUntil:
     visible: "Remove Selected"
     timeout: 10000

--- a/apps/companion/.maestro/flows/bookings/18-kit-grouping.yaml
+++ b/apps/companion/.maestro/flows/bookings/18-kit-grouping.yaml
@@ -9,6 +9,7 @@ env:
   BOOKING_NAME: "ZZX Stress"
   AUDIO_KIT: "ZZX Audio Package"
   RIG_KIT: "ZZX Projection Rig"
+  LOOSE_ASSET: "ZZX Standalone Fixture 01"
 
 ---
 # A booking that holds kits shows one row per kit, collapsed, with the members
@@ -16,15 +17,19 @@ env:
 #
 # Preconditions (GRANULAR WORKSPACE, QA database):
 #   - a RESERVED booking whose name starts "ZZX Stress", holding
-#     "ZZX Audio Package" (3 of its 3 assets) and "ZZX Projection Rig" (4 of 4)
+#     "ZZX Audio Package" (3 of its 3 assets), "ZZX Projection Rig" (4 of 4)
+#     and the standalone asset "ZZX Standalone Fixture 01"
 #   - both kits AVAILABLE
 #
-# Read-only: it opens a selection mode to prove the header selects its members,
-# then cancels. Nothing is ever submitted, so the fixture booking is unchanged.
+# Read-only: it opens a selection mode to prove a kit is picked as one unit
+# from its header, then cancels. Nothing is ever submitted, so the fixture
+# booking is unchanged.
 #
 # The kit header's accessibility label carries the whole state
-# ("Kit: <name>, <n> assets, <status>, collapsed|expanded[, selected]"), which
-# is what these assertions read — the visible text truncates.
+# ("Kit: <name>, <n> assets, <status>, collapsed|expanded[, selected]. Tap to
+# select|deselect"), which is what these assertions read — the visible text
+# truncates. An asset row's label ends ". Tap to select" only when the row has
+# a checkbox of its own.
 
 - runFlow: ../../shared/login.yaml
 
@@ -113,9 +118,10 @@ env:
 - assertVisible: ".*${AUDIO_KIT} .*item 3.*"
 - takeScreenshot: kit-expanded
 
-# ── A header selects its members ──
-# Entering a selection mode opens every kit, so a member is never hidden from a
-# selection the user is building.
+# ── A kit is picked as one unit ──
+# Entering a selection mode leaves each kit as the user left it: the Audio kit
+# opened above stays open and the Rig stays shut, each with one checkbox on its
+# header.
 # `centerElement` keeps the button clear of the nav bar — tapped flush against
 # the top edge the press lands on the header instead, and Maestro reports the
 # tap as completed either way. The wait below is what actually proves the mode
@@ -130,18 +136,55 @@ env:
 - extendedWaitUntil:
     visible: "Cancel selection"
     timeout: 10000
+# The Rig header sits above the Audio kit, so scrolling down meets it first.
 - scrollUntilVisible:
     element:
-      text: "Kit: ${RIG_KIT}, 4 assets,.*expanded.*"
+      text: "Kit: ${RIG_KIT}, 4 assets,.*collapsed. Tap to select"
     direction: DOWN
     timeout: 30000
     waitToSettleTimeoutMs: 600
-- tapOn: "Kit: ${RIG_KIT}, 4 assets,.*expanded.*"
+- scrollUntilVisible:
+    element:
+      text: ".*${AUDIO_KIT} .*item 1.*"
+    direction: DOWN
+    timeout: 30000
+    centerElement: true
+- assertVisible: "Kit: ${AUDIO_KIT}, 3 assets,.*expanded. Tap to select"
+
+# A member has no checkbox, and tapping it selects nothing.
+- assertNotVisible: ".*${AUDIO_KIT} .*item 1.*Tap to select.*"
+- tapOn: ".*${AUDIO_KIT} .*item 1.*"
+- assertVisible: "Kit: ${AUDIO_KIT}, 3 assets,.*expanded. Tap to select"
+- assertNotVisible: "Remove [0-9].*"
+- takeScreenshot: kit-members-no-checkbox
+
+# ── One tick picks the whole kit ──
+# Centred: the list scrolls under both the nav bar and the tab bar, and a tap
+# on a row flush against either lands on the bar instead.
+- scrollUntilVisible:
+    element:
+      text: "Kit: ${RIG_KIT}, 4 assets,.*collapsed. Tap to select"
+    direction: UP
+    timeout: 20000
+    centerElement: true
+- tapOn: "Kit: ${RIG_KIT}, 4 assets,.*collapsed. Tap to select"
 - extendedWaitUntil:
-    visible: "Kit: ${RIG_KIT}, 4 assets,.*expanded, selected.*"
+    visible: "Kit: ${RIG_KIT}, 4 assets,.*collapsed, selected.*"
     timeout: 10000
-# The floating action counts the members the header picked.
-- assertVisible: ".*Remove 4 selected assets.*"
+# The floating action counts the kit as one thing, however many assets it holds.
+- assertVisible: "Remove 1 Kit"
+
+# A standalone asset keeps its own checkbox and joins the count.
+- scrollUntilVisible:
+    element:
+      text: "${LOOSE_ASSET}, .*Tap to select"
+    direction: DOWN
+    timeout: 20000
+    centerElement: true
+- tapOn: "${LOOSE_ASSET}, .*Tap to select"
+- extendedWaitUntil:
+    visible: "Remove 1 Kit & 1 Asset"
+    timeout: 10000
 - takeScreenshot: kit-select-remove
 
 # ── Leave without submitting ──
@@ -154,5 +197,5 @@ env:
     centerElement: true
 - tapOn: "Cancel selection"
 - extendedWaitUntil:
-    notVisible: ".*Remove 4 selected assets.*"
+    notVisible: "Remove 1 Kit & 1 Asset"
     timeout: 10000

--- a/apps/companion/.maestro/flows/bookings/18-kit-grouping.yaml
+++ b/apps/companion/.maestro/flows/bookings/18-kit-grouping.yaml
@@ -20,6 +20,9 @@ env:
 #     "ZZX Audio Package" (3 of its 3 assets), "ZZX Projection Rig" (4 of 4)
 #     and the standalone asset "ZZX Standalone Fixture 01"
 #   - both kits AVAILABLE
+#   - rows sort by asset status, then creation, so the list reads: the Rig
+#     header, the Audio header, then the standalone assets. The scrolls below
+#     rely on that order.
 #
 # Read-only: it opens a selection mode to prove a kit is picked as one unit
 # from its header, then cancels. Nothing is ever submitted, so the fixture

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -54,8 +54,10 @@ import { BookingKitHeader } from "@/components/bookings/booking-kit-header";
 import {
   bookingRowKey,
   buildBookingRows,
+  countSelection,
   describeBookingRows,
   describeRemoval,
+  describeSelection,
   isBookingAssetSelectable,
   resolveBookingKitBadge,
   resolveKitSelectionState,
@@ -168,7 +170,8 @@ export default function BookingDetailScreen() {
   const [isActioning, setIsActioning] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // For progressive check-in/check-out: selected assets
+  // The asset ids picked in the current selection mode. A kit enters as the
+  // members its header picked; a member's own row never adds itself.
   const [selectedAssetIds, setSelectedAssetIds] = useState<Set<string>>(
     new Set()
   );
@@ -180,7 +183,8 @@ export default function BookingDetailScreen() {
   >(null);
   const isSelectMode = selectMode !== null;
   // Kits open collapsed, as on the website: a booking of several kits should
-  // read as a short list of cases, not as every asset inside them.
+  // read as a short list of cases, not as every asset inside them. Only the
+  // user opens a kit; entering a selection mode leaves them as they are.
   const [expandedKitIds, setExpandedKitIds] = useState<Set<string>>(new Set());
 
   // Sequential quantity picker for checking out QUANTITY_TRACKED assets: the
@@ -804,9 +808,13 @@ export default function BookingDetailScreen() {
   }, []);
 
   /**
-   * Picks or drops a kit's members in one tap. Only the ones the current mode
-   * can act on move, so a header in check-in mode leaves an already-returned
-   * member alone rather than selecting something the submit would drop.
+   * Picks or drops a kit's members in one tap. This is the only way a member
+   * enters a selection: a kit is picked as one unit, as on the website, so no
+   * one checks out or removes part of a kit by accident.
+   *
+   * Only the members the current mode can act on move, so a header in check-in
+   * mode leaves an already-returned member alone rather than selecting
+   * something the submit would drop.
    */
   const toggleKitSelection = useCallback(
     (members: BookingAsset[]) => {
@@ -828,26 +836,29 @@ export default function BookingDetailScreen() {
   );
 
   /**
-   * Enters or leaves a selection mode.
+   * Enters or leaves a selection mode, starting from an empty selection.
    *
-   * Entering opens every kit: the members are what a mode acts on, and a
-   * collapsed kit would hide rows from a selection the user is building.
-   * Leaving keeps the groups as the user left them.
+   * Kits stay open or closed as the user left them: a kit is picked from its
+   * header, so nothing inside it has to be on screen to be selected.
    */
-  const setSelectModeAndReveal = useCallback(
+  const toggleSelectMode = useCallback(
     (mode: "checkin" | "checkout" | "remove") => {
       setSelectMode((prev) => (prev === mode ? null : mode));
       setSelectedAssetIds(new Set());
-      setExpandedKitIds((prev) => {
-        if (selectMode === mode) return prev;
-        const next = new Set(prev);
-        for (const row of rows) {
-          if (row.type === "kit") next.add(row.kitId);
-        }
-        return next;
-      });
     },
-    [rows, selectMode]
+    []
+  );
+
+  /** What the selection holds, for the floating action button's label. */
+  const selectionCounts = useMemo(
+    () =>
+      countSelection({
+        rows,
+        selectedAssetIds,
+        selectMode,
+        checkedInAssetIds,
+      }),
+    [rows, selectedAssetIds, selectMode, checkedInAssetIds]
   );
 
   const renderAsset = useCallback(
@@ -873,15 +884,14 @@ export default function BookingDetailScreen() {
         : statusBadge[item.status] ?? fallbackBadge;
       const stateLabel = qtState ? qtState.label : formatStatus(item.status);
       const isCheckedIn = checkedInAssetIds.includes(item.id);
+      // A member of a picked kit reads as selected too, which shows what the
+      // kit's one tick covers — in check-in mode, only the members still out.
       const isSelected = selectedAssetIds.has(item.id);
-      // One definition of selectability, shared with the kit header — a header
-      // that selected a different set from the rows under it would hand the
-      // submit rows the user never saw offered.
-      const selectable = isBookingAssetSelectable(
-        item,
-        selectMode,
-        checkedInAssetIds
-      );
+      // A kit member has no checkbox of its own: its kit is picked as one unit,
+      // from the header. Standalone rows share the header's definition of what
+      // the mode can act on, so the two never offer different sets.
+      const selectable =
+        !inKit && isBookingAssetSelectable(item, selectMode, checkedInAssetIds);
 
       return (
         <TouchableOpacity
@@ -892,6 +902,10 @@ export default function BookingDetailScreen() {
             isCheckedIn && styles.assetCardCheckedIn,
           ]}
           activeOpacity={selectable ? 0.6 : 1}
+          // In a selection mode a row either toggles itself or does nothing,
+          // so a tap meant for the selection never navigates away. Disabling
+          // the inert ones lets a screen reader say so.
+          disabled={isSelectMode && !selectable}
           onPress={() => {
             if (selectable) {
               toggleAssetSelection(item.id);
@@ -1093,6 +1107,16 @@ export default function BookingDetailScreen() {
 
   /** How many kit groups the list holds; 0 means nothing is grouped. */
   const kitRowCount = rows.filter((row) => row.type === "kit").length;
+
+  // The floating action names what it acts on, counting a kit as one thing:
+  // "Check Out 1 Kit & 1 Asset".
+  const selectionActionLabel = `${
+    selectMode === "checkout"
+      ? "Check Out"
+      : selectMode === "remove"
+      ? "Remove"
+      : "Check In"
+  } ${describeSelection(selectionCounts)}`;
 
   /**
    * Why Reserve is unavailable, or null when it is fine. Mirrors all THREE of
@@ -1586,7 +1610,7 @@ export default function BookingDetailScreen() {
                     selectMode === "remove" && styles.actionButtonOutlineActive,
                   ]}
                   onPress={() => {
-                    setSelectModeAndReveal("remove");
+                    toggleSelectMode("remove");
                   }}
                   accessibilityLabel={
                     selectMode === "remove"
@@ -1645,7 +1669,7 @@ export default function BookingDetailScreen() {
                   selectMode === "checkout" && styles.actionButtonOutlineActive,
                 ]}
                 onPress={() => {
-                  setSelectModeAndReveal("checkout");
+                  toggleSelectMode("checkout");
                 }}
                 accessibilityLabel={
                   selectMode === "checkout"
@@ -1777,7 +1801,7 @@ export default function BookingDetailScreen() {
                       styles.actionButtonOutlineActive,
                   ]}
                   onPress={() => {
-                    setSelectModeAndReveal("checkin");
+                    toggleSelectMode("checkin");
                   }}
                   accessibilityLabel={
                     selectMode === "checkin"
@@ -1946,13 +1970,7 @@ export default function BookingDetailScreen() {
                 ? handleRemoveAssets
                 : handlePartialCheckin
             }
-            accessibilityLabel={`${
-              selectMode === "checkout"
-                ? "Check out"
-                : selectMode === "remove"
-                ? "Remove"
-                : "Check in"
-            } ${selectedAssetIds.size} selected assets`}
+            accessibilityLabel={selectionActionLabel}
             accessibilityRole="button"
           >
             <Ionicons
@@ -1967,13 +1985,7 @@ export default function BookingDetailScreen() {
               color={colors.primaryForeground}
             />
             <Text style={styles.floatingButtonText}>
-              {selectMode === "checkout"
-                ? "Check Out"
-                : selectMode === "remove"
-                ? "Remove"
-                : "Check In"}{" "}
-              {selectedAssetIds.size}{" "}
-              {selectedAssetIds.size === 1 ? "Asset" : "Assets"}
+              {selectionActionLabel}
             </Text>
           </TouchableOpacity>
         </View>

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -888,8 +888,9 @@ export default function BookingDetailScreen() {
       // kit's one tick covers — in check-in mode, only the members still out.
       const isSelected = selectedAssetIds.has(item.id);
       // A kit member has no checkbox of its own: its kit is picked as one unit,
-      // from the header. Standalone rows share the header's definition of what
-      // the mode can act on, so the two never offer different sets.
+      // from the header. A standalone row is offered by the same rule the header
+      // applies to its members, so an asset in a given state is selectable or
+      // not wherever it sits.
       const selectable =
         !inKit && isBookingAssetSelectable(item, selectMode, checkedInAssetIds);
 

--- a/apps/companion/lib/booking-kit-rows.test.ts
+++ b/apps/companion/lib/booking-kit-rows.test.ts
@@ -6,8 +6,9 @@
  *
  * The rules under test are the ones a screenshot cannot check: which kit a
  * quantity-tracked asset is grouped under when its slices disagree, what a
- * kit's badge says on a booking that is over, and when a removal may name the
- * kit instead of listing its assets.
+ * kit's badge says on a booking that is over, how a selection counts a kit as
+ * one thing, and when a removal may name the kit instead of listing its
+ * assets.
  *
  * @see ./booking-kit-rows.ts
  */
@@ -17,8 +18,10 @@ import { test } from "node:test";
 import {
   bookingRowKey,
   buildBookingRows,
+  countSelection,
   describeBookingRows,
   describeRemoval,
+  describeSelection,
   isBookingAssetSelectable,
   resolveBookingKitBadge,
   resolveKitSelectionState,
@@ -724,4 +727,189 @@ test("a removal names the kits before the assets", () => {
   );
   assert.equal(describeRemoval({ assetCount: 3, kitCount: 0 }), "3 assets");
   assert.equal(describeRemoval({ assetCount: 0, kitCount: 2 }), "2 kits");
+});
+
+test("a removal with nothing to name still names assets", () => {
+  assert.equal(describeRemoval({ assetCount: 0, kitCount: 0 }), "0 assets");
+  assert.equal(
+    describeRemoval({ assetCount: 1, kitCount: 1 }),
+    "1 kit and 1 asset"
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The floating action's label
+// ---------------------------------------------------------------------------
+
+test("a selection names kits before assets, joined by an ampersand", () => {
+  assert.equal(
+    describeSelection({ kitCount: 1, assetCount: 1 }),
+    "1 Kit & 1 Asset"
+  );
+  assert.equal(
+    describeSelection({ kitCount: 1, assetCount: 2 }),
+    "1 Kit & 2 Assets"
+  );
+  assert.equal(
+    describeSelection({ kitCount: 2, assetCount: 1 }),
+    "2 Kits & 1 Asset"
+  );
+  assert.equal(
+    describeSelection({ kitCount: 3, assetCount: 4 }),
+    "3 Kits & 4 Assets"
+  );
+});
+
+test("a selection of only kits does not mention assets", () => {
+  assert.equal(describeSelection({ kitCount: 1, assetCount: 0 }), "1 Kit");
+  assert.equal(describeSelection({ kitCount: 2, assetCount: 0 }), "2 Kits");
+});
+
+test("a selection of only assets does not mention kits", () => {
+  assert.equal(describeSelection({ kitCount: 0, assetCount: 1 }), "1 Asset");
+  assert.equal(describeSelection({ kitCount: 0, assetCount: 3 }), "3 Assets");
+});
+
+test("an empty selection still reads as a count", () => {
+  assert.equal(describeSelection({ kitCount: 0, assetCount: 0 }), "0 Assets");
+});
+
+/** Two kits and a standalone asset, as the list renders them. */
+function kitsAndLooseAsset(expandedKitIds: ReadonlySet<string>): BookingRow[] {
+  return buildBookingRows({
+    assets: [
+      inKit("m1", "kit-1", "Camera Kit"),
+      inKit("m2", "kit-1", "Camera Kit"),
+      inKit("m3", "kit-1", "Camera Kit"),
+      inKit("r1", "kit-2", "Rig"),
+      inKit("r2", "kit-2", "Rig"),
+      asset({ id: "loose-1" }),
+      asset({ id: "loose-2" }),
+    ],
+    kits: [
+      { ...cameraKit, assetCount: 3 },
+      { ...cameraKit, id: "kit-2", name: "Rig", assetCount: 2 },
+    ],
+    expandedKitIds,
+  });
+}
+
+test("a picked kit counts once, however many members it holds", () => {
+  assert.deepEqual(
+    countSelection({
+      rows: kitsAndLooseAsset(new Set()),
+      selectedAssetIds: new Set(["m1", "m2", "m3"]),
+      selectMode: "checkout",
+      checkedInAssetIds: [],
+    }),
+    { kitCount: 1, assetCount: 0 }
+  );
+});
+
+test("a standalone asset beside a picked kit counts as one asset", () => {
+  assert.deepEqual(
+    countSelection({
+      rows: kitsAndLooseAsset(new Set()),
+      selectedAssetIds: new Set(["m1", "m2", "m3", "loose-1"]),
+      selectMode: "checkout",
+      checkedInAssetIds: [],
+    }),
+    { kitCount: 1, assetCount: 1 }
+  );
+});
+
+test("every picked kit and every standalone asset is counted", () => {
+  assert.deepEqual(
+    countSelection({
+      rows: kitsAndLooseAsset(new Set()),
+      selectedAssetIds: new Set([
+        "m1",
+        "m2",
+        "m3",
+        "r1",
+        "r2",
+        "loose-1",
+        "loose-2",
+      ]),
+      selectMode: "remove",
+      checkedInAssetIds: [],
+    }),
+    { kitCount: 2, assetCount: 2 }
+  );
+});
+
+test("opening a kit does not change what the selection counts", () => {
+  const selectedAssetIds = new Set(["r1", "r2", "loose-2"]);
+  const collapsed = countSelection({
+    rows: kitsAndLooseAsset(new Set()),
+    selectedAssetIds,
+    selectMode: "checkout",
+    checkedInAssetIds: [],
+  });
+  const expanded = countSelection({
+    rows: kitsAndLooseAsset(new Set(["kit-1", "kit-2"])),
+    selectedAssetIds,
+    selectMode: "checkout",
+    checkedInAssetIds: [],
+  });
+  assert.deepEqual(collapsed, { kitCount: 1, assetCount: 1 });
+  assert.deepEqual(expanded, collapsed);
+});
+
+test("in check-in a kit counts once its outstanding members are picked", () => {
+  // m1 is out; m2 never left, so check-in cannot act on it. Picking m1 alone
+  // is the whole of what the header offers.
+  const rows = buildBookingRows({
+    assets: [
+      asset({
+        id: "m1",
+        kitId: "kit-1",
+        kit: { id: "kit-1", name: "Camera Kit" },
+        status: "CHECKED_OUT",
+      }),
+      asset({
+        id: "m2",
+        kitId: "kit-1",
+        kit: { id: "kit-1", name: "Camera Kit" },
+        status: "AVAILABLE",
+      }),
+    ],
+    kits: [cameraKit],
+    expandedKitIds: new Set(),
+  });
+  assert.deepEqual(
+    countSelection({
+      rows,
+      selectedAssetIds: new Set(["m1"]),
+      selectMode: "checkin",
+      checkedInAssetIds: [],
+    }),
+    { kitCount: 1, assetCount: 0 }
+  );
+});
+
+test("members of a partly picked kit count as the assets they are", () => {
+  // The header reads "some", so the kit is not picked whole; the label still
+  // covers the member the submit will send.
+  assert.deepEqual(
+    countSelection({
+      rows: kitsAndLooseAsset(new Set()),
+      selectedAssetIds: new Set(["m1"]),
+      selectMode: "remove",
+      checkedInAssetIds: [],
+    }),
+    { kitCount: 0, assetCount: 1 }
+  );
+});
+
+test("nothing picked counts nothing", () => {
+  assert.deepEqual(
+    countSelection({
+      rows: kitsAndLooseAsset(new Set()),
+      selectedAssetIds: new Set(),
+      selectMode: "checkout",
+      checkedInAssetIds: [],
+    }),
+    { kitCount: 0, assetCount: 0 }
+  );
 });

--- a/apps/companion/lib/booking-kit-rows.test.ts
+++ b/apps/companion/lib/booking-kit-rows.test.ts
@@ -725,16 +725,16 @@ test("a removal names the kits before the assets", () => {
     describeRemoval({ assetCount: 2, kitCount: 1 }),
     "1 kit and 2 assets"
   );
+  assert.equal(
+    describeRemoval({ assetCount: 1, kitCount: 1 }),
+    "1 kit and 1 asset"
+  );
   assert.equal(describeRemoval({ assetCount: 3, kitCount: 0 }), "3 assets");
   assert.equal(describeRemoval({ assetCount: 0, kitCount: 2 }), "2 kits");
 });
 
 test("a removal with nothing to name still names assets", () => {
   assert.equal(describeRemoval({ assetCount: 0, kitCount: 0 }), "0 assets");
-  assert.equal(
-    describeRemoval({ assetCount: 1, kitCount: 1 }),
-    "1 kit and 1 asset"
-  );
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/companion/lib/booking-kit-rows.ts
+++ b/apps/companion/lib/booking-kit-rows.ts
@@ -3,10 +3,10 @@
  *
  * The booking endpoint sends a flat list of assets plus the kits they belong
  * to. This module turns those two into the rows the screen renders — one
- * header per kit followed by its members when expanded — and answers the three
+ * header per kit followed by its members when expanded — and answers the
  * questions that grouping raises: what the kit's badge says, which members a
- * header may select, and whether a removal may name the kit instead of its
- * assets.
+ * header may select, how a selection reads on the action button, and whether a
+ * removal may name the kit instead of its assets.
  *
  * Everything here is pure and free of React Native so the rules can be tested
  * under Node. The screen owns the pixels; this owns the decisions.
@@ -301,17 +301,21 @@ export function resolveBookingKitBadge({
 export type BookingSelectMode = "checkin" | "checkout" | "remove" | null;
 
 /**
- * Whether a row can be picked in the current mode.
+ * Whether the current mode can act on an asset.
+ *
+ * This answers for the asset, not for where it is drawn. A standalone row is
+ * picked by its own tap when this holds; a kit member is never picked from its
+ * own row, and its header uses this to decide which members one tick picks.
  *
  * Quantity-tracked assets are judged by units, not status: a partly
  * checked-out one stays AVAILABLE while units are still reserved. A returned
  * individual asset is AVAILABLE again too, so check-out excludes the ones
  * already checked in rather than re-offering them.
  *
- * @param item - the asset row
+ * @param item - the asset
  * @param selectMode - the active mode, or null when not selecting
  * @param checkedInAssetIds - assets already checked back in
- * @returns true when tapping the row toggles its selection
+ * @returns true when the mode can act on the asset
  */
 export function isBookingAssetSelectable(
   item: BookingAsset,
@@ -367,6 +371,61 @@ export function resolveKitSelectionState({
   ).length;
   if (picked === 0) return "none";
   return picked === selectable.length ? "all" : "some";
+}
+
+/** What a selection holds, with a wholly picked kit counted as one thing. */
+export type SelectionCounts = { kitCount: number; assetCount: number };
+
+/**
+ * Counts a selection the way the list offers it: a kit is one thing, and every
+ * other pick is an asset.
+ *
+ * `kitCount` is the kit headers that read "all" — every member the mode can act
+ * on is picked. `assetCount` is every selected id those kits do not account
+ * for. A member is only ever picked through its header, so these are normally
+ * the standalone rows; an id outside every wholly picked kit still counts, so
+ * the label covers everything the submit will send.
+ *
+ * @param args.rows - the rendered rows; a kit header carries every member
+ *   whether or not the kit is open
+ * @param args.selectedAssetIds - the current selection
+ * @param args.selectMode - the active mode
+ * @param args.checkedInAssetIds - assets already checked back in
+ * @returns the counts `describeSelection` names
+ */
+export function countSelection({
+  rows,
+  selectedAssetIds,
+  selectMode,
+  checkedInAssetIds,
+}: {
+  rows: BookingRow[];
+  selectedAssetIds: ReadonlySet<string>;
+  selectMode: BookingSelectMode;
+  checkedInAssetIds: readonly string[];
+}): SelectionCounts {
+  let kitCount = 0;
+  const coveredByKit = new Set<string>();
+
+  for (const row of rows) {
+    if (row.type !== "kit") continue;
+    const state = resolveKitSelectionState({
+      members: row.members,
+      selectMode,
+      selectedAssetIds,
+      checkedInAssetIds,
+    });
+    if (state !== "all") continue;
+    kitCount += 1;
+    for (const member of row.members) coveredByKit.add(member.id);
+  }
+
+  let assetCount = 0;
+  for (const id of selectedAssetIds) {
+    if (!coveredByKit.has(id)) assetCount += 1;
+  }
+
+  return { kitCount, assetCount };
 }
 
 /**
@@ -450,9 +509,48 @@ export function splitRemovalSelection({
   };
 }
 
+/** The words one kits-then-assets phrase is written in. */
+type KitsThenAssetsWording = {
+  kit: { one: string; many: string };
+  asset: { one: string; many: string };
+  joiner: string;
+};
+
+/**
+ * Names kits and assets, kits first because a kit is the larger thing.
+ *
+ * A kits-only count drops the asset half ("2 kits", not "2 kits and 0
+ * assets"); a count of nothing still names assets, so the phrase is never
+ * empty.
+ *
+ * @param counts - how many kits and assets to name
+ * @param wording - the nouns and the word that joins the two halves
+ * @returns e.g. `"1 kit and 2 assets"` or `"1 Kit & 2 Assets"`
+ */
+function describeKitsThenAssets(
+  { kitCount, assetCount }: SelectionCounts,
+  wording: KitsThenAssetsWording
+): string {
+  const parts: string[] = [];
+  if (kitCount > 0) {
+    parts.push(
+      `${kitCount} ${kitCount === 1 ? wording.kit.one : wording.kit.many}`
+    );
+  }
+  if (assetCount > 0 || kitCount === 0) {
+    parts.push(
+      `${assetCount} ${
+        assetCount === 1 ? wording.asset.one : wording.asset.many
+      }`
+    );
+  }
+  return parts.join(wording.joiner);
+}
+
 /**
  * Names what a removal will take, leading with the kits because a kit is the
- * larger thing leaving the booking.
+ * larger thing leaving the booking. Reads inside a sentence, so it is lower
+ * case.
  *
  * @param args.assetCount - assets removed by id
  * @param args.kitCount - kits removed as a whole
@@ -465,12 +563,38 @@ export function describeRemoval({
   assetCount: number;
   kitCount: number;
 }): string {
-  const parts: string[] = [];
-  if (kitCount > 0) {
-    parts.push(`${kitCount} ${kitCount === 1 ? "kit" : "kits"}`);
-  }
-  if (assetCount > 0 || kitCount === 0) {
-    parts.push(`${assetCount} ${assetCount === 1 ? "asset" : "assets"}`);
-  }
-  return parts.join(" and ");
+  return describeKitsThenAssets(
+    { kitCount, assetCount },
+    {
+      kit: { one: "kit", many: "kits" },
+      asset: { one: "asset", many: "assets" },
+      joiner: " and ",
+    }
+  );
+}
+
+/**
+ * Names a selection on the floating action button, after its verb:
+ * "Check Out 1 Kit & 1 Asset". The verb is Title Case, so the counts are too,
+ * and the ampersand keeps a two-part label on one line.
+ *
+ * The screen reader label uses the same words, so the button sounds the way it
+ * reads.
+ *
+ * @param args.kitCount - kits picked whole, from `countSelection`
+ * @param args.assetCount - picks outside a whole kit, from `countSelection`
+ * @returns e.g. `"1 Kit & 1 Asset"`, `"2 Kits"`, `"3 Assets"`
+ */
+export function describeSelection({
+  kitCount,
+  assetCount,
+}: SelectionCounts): string {
+  return describeKitsThenAssets(
+    { kitCount, assetCount },
+    {
+      kit: { one: "Kit", many: "Kits" },
+      asset: { one: "Asset", many: "Assets" },
+      joiner: " & ",
+    }
+  );
 }

--- a/apps/companion/lib/booking-kit-rows.ts
+++ b/apps/companion/lib/booking-kit-rows.ts
@@ -576,7 +576,7 @@ export function describeRemoval({
 /**
  * Names a selection on the floating action button, after its verb:
  * "Check Out 1 Kit & 1 Asset". The verb is Title Case, so the counts are too,
- * and the ampersand keeps a two-part label on one line.
+ * and the ampersand keeps a two-part label short.
  *
  * The screen reader label uses the same words, so the button sounds the way it
  * reads.


### PR DESCRIPTION
## What

On the booking screen, "Select to Check Out", "Select to Check In" and "Select to Remove" used to open every kit and give each kit member its own tick box. A kit then read as a long run of tick boxes, and part of a kit could be checked out or removed by accident. The web does the opposite, and the app now mirrors it:

- **Kits stay as the user left them.** Entering a selection mode no longer opens kits, so they stay collapsed unless the user opened one. The header's chevron still opens a kit in select mode, so people can look inside.
- **The kit header tick is the only way to pick a kit.** One tap picks every member the current mode can act on (in check-in mode, only the members still out). A second tap drops them. This is the existing header behaviour, unchanged.
- **Kit members have no tick box and select nothing when tapped** in any selection mode. Outside a selection mode a member still opens its asset. Members of a picked kit keep the "selected" tint, which shows what the kit's tick covers. In a selection mode, inert rows are `disabled`, so a screen reader announces them as dimmed.
- **Standalone assets keep their own tick box.**
- **The floating button names what it acts on**, counting a kit as one thing: `Check Out 1 Kit & 1 Asset`, `Remove 2 Kits`, `Check In 3 Assets`. Its screen reader label uses the same words.

Web references: kits collapsed by default (`booking-assets-column.tsx`), the kit checkbox selects the kit and its members (`kit-row.tsx`), member rows get an empty cell instead of a checkbox (`list-asset-content.tsx`).

## How the button counts

`countSelection` (in `lib/booking-kit-rows.ts`) counts a kit once its header reads "all", meaning every member the mode can act on is picked. Every other selected id counts as an asset. Members are only picked through their header, so in practice these are the standalone rows, and the label always covers everything the submit sends. `describeSelection` turns the counts into Title Case with an ampersand. It shares its "kits first, never empty" phrasing with `describeRemoval` through one private helper, and the removal wording is unchanged.

The server calls are unchanged. A picked kit still travels as its members' asset ids, and `splitRemovalSelection` still decides when a removal may name the kit.

## Known differences from the web

- On the web, a kit member's row menu can remove that one member from the booking. The phone list has no per-row menu, so a member leaves the booking only with its whole kit. This is by design.
- The web can check out part of a kit through its scanner. The phone's scan-to-check-out is #3002; from the phone list a kit goes out whole.
- The check-out and check-in confirm dialogs still count assets ("Check out 5 selected assets?"), because that is what the endpoint receives.
- The remove dialog keeps `describeRemoval`, which names what the removal sends, and `splitRemovalSelection` names a kit only when the booking holds all of it. So a kit the booking holds only in part reads "Remove 1 Kit" on the button, while the dialog counts its assets. If such a kit is picked together with a whole kit, the existing split rule sends both as asset ids, and the dialog counts all of their assets.

## Maestro

- `18-kit-grouping.yaml`: after entering remove mode, it asserts the opened kit stays open and the other stays collapsed. It checks that a member row offers no tick box and that tapping it selects nothing. The kit header tick then reads `Remove 1 Kit`, and adding a standalone asset reads `Remove 1 Kit & 1 Asset`. Header taps are centred, because the list scrolls under the nav bar and the tab bar.
- `07-create-add-reserve-edit-remove.yaml`: reads the new button label (`Remove 1 Asset`). It picks the workspace with a trailing wildcard, since the picker labels the active one "(current)".
- `03b-checkin-skips-unchecked-kit-member.yaml`, `04-checkout-flow.yaml` and `05-checkin-flow.yaml` tick no kit member and are unchanged.

## Tests

- `lib/booking-kit-rows.test.ts` (`node --test`), 12 new cases. Wording: every singular and plural combination, kits-only, assets-only, and the empty form. Counting: a picked kit counts once; a standalone asset beside a kit; two kits and two assets; opening a kit does not change the count; in check-in a kit counts once its outstanding members are picked; members of a partly picked kit count as assets; nothing picked. Five of the seven counting cases fail against the old raw-id count; the other two are cases where both counts agree.
- Companion `typecheck`, `lint` and `test` (131 of 131 pass). React Doctor in diff mode reports no errors.

## Verified on the iOS simulator

Local webapp and Metro from this branch, QA data, an owner account in a team workspace.

- Select to Check Out on a reserved booking with two kits and a standalone asset: both kits stay collapsed with one tick box each. One kit tick plus the standalone asset reads `Check Out 1 Kit & 1 Asset`.
- A kit opened before entering the mode stays open. Its members show no tick box, and tapping one changes nothing. Ticking the header tints the members and reads `Check Out 1 Kit & 1 Asset`. A second tap drops the kit, and the button reads `Check Out 1 Asset`.
- Select to Remove on the same booking and on the fixture booking of flow 18: `Remove 1 Kit`, then `Remove 1 Kit & 1 Asset`.
- Flow 18 passes on the simulator. Flow 07 passes through its create, add and remove steps with the new label. Nothing was submitted from a selection except flow 07's removal of the asset it had just added.

## Ship path

- Client only, in `apps/companion`. No server change, no migration.
- Ships by OTA on runtime 1.5.0. The app reads the same booking payload as before.
- #3002 edits the same screen file for scan-to-check-out, in different regions. Whichever merges second rebases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kit selection is now handled as a single unit from the kit header.
  * Selection actions clearly distinguish kits and individual assets, including combined selections.
  * Eligible users can scan assets to check them out progressively.
* **Bug Fixes**
  * Kit expansion states are preserved when entering selection mode.
  * Kit members can no longer be selected or activated individually during selection.
  * Improved accessibility and interaction behavior for unavailable asset rows.
  * Checkout availability now reflects booking-specific asset quantities and permissions.
  * Updated booking flows to match current workspace and removal confirmation labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->