### PR TITLE
fix(api): re-sign expired kit images for the companion

### DIFF
--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
@@ -26,6 +26,7 @@ import {
 } from "~/modules/booking/service.server";
 import { calculateBookingLifecycleProgress } from "~/modules/booking/utils.server";
 import { getBookingSettingsForOrganization } from "~/modules/booking-settings/service.server";
+import { refreshExpiredKitImages } from "~/modules/kit/service.server";
 import { canSeeBooking } from "~/utils/booking-authorization.server";
 import { makeShelfError } from "~/utils/error";
 import { getParams } from "~/utils/http.server";
@@ -39,6 +40,8 @@ import { hasPermission } from "~/utils/permissions/permission.validator.server";
  * GET /api/mobile/bookings/:bookingId
  *
  * Returns full booking detail with assets, custodian, and check-in status.
+ * A kit image whose signed URL has lapsed is re-signed, and the new URL
+ * written back to the kit, before it is sent.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
   try {
@@ -545,7 +548,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     // own. It is org-scoped as well as id-scoped: a kit id reaching this query
     // came from a BookingAsset row, but scoping it keeps the response's kit
     // payload inside the caller's workspace by construction.
-    const [sliceRows, checkoutSessionRows, kitRows] = await Promise.all([
+    const [sliceRows, checkoutSessionRows, storedKitRows] = await Promise.all([
       db.bookingAsset.findMany({
         where: { bookingId: booking.id },
         select: {
@@ -566,6 +569,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
             where: { id: { in: bookingKitIds }, organizationId },
             select: {
               id: true,
+              // Scopes the write-back of a re-signed image below.
+              organizationId: true,
               name: true,
               status: true,
               image: true,
@@ -581,6 +586,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
           })
         : Promise.resolve([]),
     ]);
+    // A kit's `image` is a signed storage URL that stops working once
+    // `imageExpiration` passes, and the app has no way to renew it. Re-sign the
+    // lapsed ones so a kit header never receives a dead link. `organizationId`
+    // only scopes that write-back, so it is dropped before the response.
+    const kitRows = (await refreshExpiredKitImages(storedKitRows)).map(
+      ({ organizationId: _organizationId, ...kit }) => kit
+    );
     const dispatchedUnitsByAsset = computeDispatchedUnitsByAsset({
       slices: sliceRows,
       checkoutSessions: checkoutSessionRows,

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
@@ -74,17 +74,18 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
          * Draft privacy (web parity). A DRAFT booking is private to its
          * creator — web gates the detail route on the same shared clause, so
          * without it a direct GET here returns a colleague's unfinished draft
-         * even though the list hides it. The list fix alone is not enough:
-         * booking ids are guessable-adjacent and this endpoint is reachable
-         * directly. The booking override does NOT widen this: an unfinished
-         * draft stays private to its creator either way, exactly as on web.
+         * even though the list hides it. Hiding drafts from the list is not
+         * enough: booking ids are guessable-adjacent and this endpoint is
+         * reachable directly. The booking override does NOT widen this: an
+         * unfinished draft stays private to its creator either way, exactly as
+         * on web.
          *
          * Custody is deliberately NOT a clause here. It is a gate on the
          * loaded row instead (`canSeeBooking`, just past the 404 below), so
          * "you may not see this" answers 403 rather than reporting the row as
-         * missing. Putting it back in the `where` also silently re-decides
-         * visibility before the row is read, which is where it stops being
-         * able to honour the workspace override.
+         * missing. A custody clause in the `where` would also silently
+         * re-decide visibility before the row is read, where it can no longer
+         * honour the workspace override.
          */
         AND: [bookingDraftVisibilityClause(user.id)],
       },
@@ -237,9 +238,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     // = mixed standalone + kit-driven). Mobile clients that don't know
     // about `assetKitId` see the same flat shape they always did.
     //
-    // `slices` additively exposes the per-BookingAsset-row breakdown (Gap 1,
-    // Companion QT display parity) so the app can render standalone vs.
-    // kit-driven booked units separately instead of only the merged total.
+    // `slices` exposes the per-BookingAsset-row breakdown so the app can
+    // render standalone vs. kit-driven booked units separately instead of only
+    // the merged total.
     type SliceRow = {
       bookingAssetId: string;
       quantity: number;
@@ -290,17 +291,17 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       // why: no `sourceKitId` fallback for detached kit residue here. This
       // response collapses per asset rather than grouping by kit, and the
       // unanimous rule below deliberately reports `null` rather than guessing
-      // a source. Resolving the snapshot kit would re-introduce exactly the
-      // arbitrary attribution that rule exists to remove.
+      // a source. Resolving the snapshot kit would produce exactly the
+      // arbitrary attribution that rule prevents.
       // Unanimous-kit rule: every collapsed row for this asset points at
       // the same `assetKitId`. Mixed → `null` so clients don't
       // mis-attribute the slice to one of multiple sources.
       const unanimousAssetKitId =
         row.assetKitIds.size === 1 ? Array.from(row.assetKitIds)[0] : null;
-      // Merged kit = the kit of the unanimous membership, else null. This
-      // REPLACES the legacy `assetKits[0].kit` synthesis, which mislabelled
-      // standalone/mixed rows with an arbitrary membership. Safe for old
-      // clients: they already render a null kit (INDIVIDUAL assets have one).
+      // Merged kit = the kit of the unanimous membership, else null. Never
+      // fall back to an arbitrary membership such as `assetKits[0].kit`: it
+      // mislabels standalone and mixed rows. Safe for old clients: they
+      // already render a null kit (INDIVIDUAL assets have one).
       const mergedKit =
         unanimousAssetKitId != null
           ? assetKits.find((ak) => ak.id === unanimousAssetKitId)?.kit ?? null
@@ -375,9 +376,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     // Checkinable while ONGOING/OVERDUE AND something is still to check in.
     // INDIVIDUAL: global status CHECKED_OUT. QUANTITY_TRACKED: booked units not
     // yet reconciled = remainingToCheckIn > 0 (booked − returned/consumed/lost/
-    // damaged) — the SAME "remaining" the web check-in drawer caps at. The old
-    // `checkedOutCount > 0` gate hid check-in on a partially-checked-out QT
-    // booking, whose asset status stays AVAILABLE while units are still booked.
+    // damaged) — the SAME "remaining" the web check-in drawer caps at. A QT
+    // asset's status stays AVAILABLE while units are still booked, so a
+    // status-based gate (`checkedOutCount > 0`) would hide check-in on a
+    // partially-checked-out QT booking.
     const hasCheckinable = assets.some((a) => {
       if (a.type === AssetType.QUANTITY_TRACKED) {
         const rem = remainingByAsset.get(a.id);
@@ -391,8 +393,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
     // Quick "check in all" is disallowed when the workspace requires EXPLICIT
     // (scan/select) check-in for the caller's role — mirror the web policy
-    // (overview.tsx:1034-1054) so the app never offers an action the web /
-    // workspace settings forbid.
+    // (the `checkIn` case of the booking overview action) so the app never
+    // offers an action the web / workspace settings forbid.
     const bookingSettings =
       await getBookingSettingsForOrganization(organizationId);
     const canQuickCheckin = !(
@@ -658,12 +660,11 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     });
 
     /**
-     * The third rule web's Reserve button disables on, which the companion had
-     * no way to evaluate: whether any asset is already booked for this window.
-     * Unlike "no assets" and "unavailable asset", it cannot be derived from the
-     * rows in this response — it needs the overlapping-booking query — so
-     * without this flag the phone showed an enabled Reserve, the user tapped,
-     * confirmed, and only then got a 400 from `reserveBooking`'s conflict check.
+     * The third rule web's Reserve button disables on: whether any asset is
+     * already booked for this window. Unlike "no assets" and "unavailable
+     * asset", it cannot be derived from the rows in this response — it needs
+     * the overlapping-booking query — so without this flag the app would offer
+     * a Reserve that `reserveBooking`'s conflict check then refuses with a 400.
      *
      * Computed for DRAFT bookings only: Reserve is the sole consumer and it is
      * the only status that renders it, so no other request pays for the query.

--- a/apps/webapp/app/routes/api+/mobile+/kits.$kitId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/kits.$kitId.ts
@@ -21,6 +21,7 @@ import {
 import { viewerCanSeeLegacyCustody } from "~/modules/api/mobile-custody-visibility.server";
 import { serializeAssetImage } from "~/modules/asset/image-resolution";
 import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
+import { refreshExpiredKitImages } from "~/modules/kit/service.server";
 import { makeShelfError } from "~/utils/error";
 import { getParams } from "~/utils/http.server";
 import {
@@ -33,7 +34,9 @@ import {
  *
  * Returns full kit detail for the companion app's kit screen: status,
  * custody, description, image, and the contained assets (each tappable
- * through to the asset detail screen).
+ * through to the asset detail screen). A kit image whose signed URL has
+ * lapsed is re-signed, and the new URL written back to the kit, before it is
+ * sent.
  *
  * @param args - React Router loader args.
  * @param args.request - Incoming request; carries the mobile bearer auth and
@@ -62,11 +65,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
     const { kitId } = getParams(params, z.object({ kitId: z.string() }));
 
-    const kit = await db.kit.findFirst({
+    const storedKit = await db.kit.findFirst({
       // org-scoped lookup — a foreign-org kit id resolves to null (404)
       where: { id: kitId, organizationId },
       select: {
         id: true,
+        // Scopes the write-back of a re-signed image below.
+        organizationId: true,
         name: true,
         description: true,
         status: true,
@@ -146,12 +151,19 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       },
     });
 
-    if (!kit) {
+    if (!storedKit) {
       return data(
         { error: { message: "Kit not found in this workspace." } },
         { status: 404 }
       );
     }
+
+    // A kit's `image` is a signed storage URL that stops working once
+    // `imageExpiration` passes, and the app has no way to renew it. Re-sign a
+    // lapsed one so the kit screen never receives a dead link. `organizationId`
+    // only scopes that write-back, so it is dropped before the response.
+    const [refreshedKit] = await refreshExpiredKitImages([storedKit]);
+    const { organizationId: _organizationId, ...kit } = refreshedKit;
 
     // Flatten the AssetKit pivot into the asset list the companion expects.
     // Also flatten the `assetLocations[0]` pivot back into the singular

--- a/apps/webapp/app/routes/api+/mobile+/kits.$kitId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/kits.$kitId.ts
@@ -107,9 +107,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
           },
         },
         // Kit ↔ Asset membership is the AssetKit pivot (see schema).
-        // Select through the pivot and synthesise a flat `assets` array
-        // below so the mobile JSON contract stays unchanged for the
-        // companion app (kit screen still receives `kit.assets[]`).
+        // Select through the pivot and synthesise the flat `kit.assets[]`
+        // array below, which is the shape the companion's kit screen reads.
         assetKits: {
           select: {
             // AssetKit.quantity — units of THIS asset held by THIS kit (the
@@ -135,10 +134,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
                 // its model's photo is not blank on the kit detail screen.
                 ...ASSET_MODEL_IMAGE_SELECT,
                 category: { select: { id: true, name: true } },
-                // Post-Phase-4b: `Asset.location` was replaced by the
-                // `AssetLocation` pivot. Project the primary placement
-                // through the pivot and flatten back to a single `location`
-                // field below so the mobile JSON contract stays unchanged.
+                // Placement lives on the `AssetLocation` pivot. Project the
+                // primary placement through it; it is flattened below into
+                // the single `location` field the mobile JSON contract
+                // carries.
                 assetLocations: {
                   select: { location: { select: { id: true, name: true } } },
                   take: 1,
@@ -193,10 +192,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
     /**
      * `kit: read` is held by BASE and SELF_SERVICE, and this select reaches
-     * `custodian.user.email`. The mobile asset detail route already nulls its
-     * legacy custody field for viewers who may not see it; this one had no
-     * gate at all. Null the whole object rather than emptying the custodian —
-     * that is the established shape on the mobile surface.
+     * `custodian.user.email`. For a viewer who may not see the holder, null
+     * the whole custody object rather than emptying the custodian: that is the
+     * established shape on the mobile surface, and the mobile asset detail
+     * route does the same with its legacy custody field.
      */
     const visibleCustody =
       kitData.custody &&

--- a/apps/webapp/app/routes/api+/mobile+/kits.ts
+++ b/apps/webapp/app/routes/api+/mobile+/kits.ts
@@ -7,6 +7,7 @@ import {
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
 import { viewerCanSeeLegacyCustody } from "~/modules/api/mobile-custody-visibility.server";
+import { refreshExpiredKitImages } from "~/modules/kit/service.server";
 import { makeShelfError } from "~/utils/error";
 import {
   PermissionAction,
@@ -18,7 +19,9 @@ import {
  *
  * Returns paginated kits for the given organization, each with its category,
  * location, asset count, and custodian. Mirrors the mobile assets list route
- * (search, infinite scroll, status filter, and the my-custody filter).
+ * (search, infinite scroll, status filter, and the my-custody filter). A kit
+ * image whose signed URL has lapsed is re-signed, and the new URL written back
+ * to the kit, before it is sent.
  *
  * @see {@link file://./assets.ts} the asset twin of this route
  */
@@ -66,11 +69,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
       ...(myCustody ? { custody: { custodian: { userId: user.id } } } : {}),
     };
 
-    const [kits, totalCount] = await Promise.all([
+    const [storedKits, totalCount] = await Promise.all([
       db.kit.findMany({
         where,
         select: {
           id: true,
+          // Scopes the write-back of a re-signed image below.
+          organizationId: true,
           name: true,
           status: true,
           image: true,
@@ -95,6 +100,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
       }),
       db.kit.count({ where }),
     ]);
+
+    // A kit's `image` is a signed storage URL that stops working once
+    // `imageExpiration` passes, and the app has no way to renew it. Re-sign the
+    // lapsed ones so the list never receives a dead link. `organizationId` only
+    // scopes that write-back, so it is dropped before the response.
+    const kits = (await refreshExpiredKitImages(storedKits)).map(
+      ({ organizationId: _organizationId, ...kit }) => kit
+    );
 
     // Re-shape `_count.assetKits` → `_count.assets` so the response matches
     // the contract the companion app already consumes (see

--- a/apps/webapp/app/routes/api+/mobile+/kits.ts
+++ b/apps/webapp/app/routes/api+/mobile+/kits.ts
@@ -81,8 +81,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
           image: true,
           imageExpiration: true,
           // Kits link to assets via the `AssetKit` pivot model — count that
-          // relation, then re-key to `assets` below so the mobile companion's
-          // existing API contract (`_count.assets`) is preserved.
+          // relation, then re-key it below to `_count.assets`, the key the
+          // companion reads.
           _count: { select: { assetKits: true } },
           category: { select: { id: true, name: true } },
           location: { select: { id: true, name: true } },
@@ -116,10 +116,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
       ...rest,
       _count: { assets: _count.assetKits },
       /**
-       * `kit: read` is held by BASE and SELF_SERVICE, and this list had no
-       * custody gate at all — a restricted viewer read every kit's holder
-       * from it. Null the object for holders the viewer may not see, matching
-       * the mobile detail routes; the caller's own custody stays visible.
+       * `kit: read` is held by BASE and SELF_SERVICE, so a restricted viewer
+       * reaches this list. Null the object for holders the viewer may not
+       * see, matching the mobile detail routes; the caller's own custody
+       * stays visible.
        */
       custody:
         rest.custody &&

--- a/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.kits.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.kits.test.ts
@@ -12,6 +12,9 @@
  *    missing and not every kit in the workspace.
  * 3. The lookup is scoped to the caller's organization, so a kit id that does
  *    not belong to it can never be described back.
+ * 4. A kit's `image` is a signed URL the app cannot renew, so the kit rows go
+ *    through `refreshExpiredKitImages` before they are sent: a lapsed URL
+ *    arrives re-signed, with the `imageExpiration` the helper returned.
  *
  * @see {@link file://./bookings.$bookingId.ts} loader under test
  */
@@ -28,6 +31,7 @@ import {
   getMobileUserContext,
 } from "~/modules/api/mobile-auth.server";
 import type * as BookingServiceServer from "~/modules/booking/service.server";
+import { refreshExpiredKitImages } from "~/modules/kit/service.server";
 
 import { loader } from "~/routes/api+/mobile+/bookings.$bookingId";
 
@@ -98,11 +102,19 @@ vi.mock("~/utils/permissions/permission.validator.server", () => ({
   hasPermission: vi.fn().mockResolvedValue(false),
 }));
 
+// why: re-signing calls Supabase Storage and writes the new URL back to the
+// kit row. The helper has its own contract; the kit-image case below pins what
+// the loader does with it, and every other case gets its rows back untouched.
+vi.mock("~/modules/kit/service.server", () => ({
+  refreshExpiredKitImages: vi.fn((kits: unknown[]) => Promise.resolve(kits)),
+}));
+
 const findFirstMock = vi.mocked(db.booking.findFirst);
 const kitFindManyMock = vi.mocked(db.kit.findMany);
 const requireMobileAuthMock = vi.mocked(requireMobileAuth);
 const requireOrganizationAccessMock = vi.mocked(requireOrganizationAccess);
 const getMobileUserContextMock = vi.mocked(getMobileUserContext);
+const refreshExpiredKitImagesMock = vi.mocked(refreshExpiredKitImages);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -292,6 +304,47 @@ describe("GET /api/mobile/bookings/:bookingId — the kits its assets group unde
 
     expect(kitsFrom(await get())).toEqual([]);
     expect(kitFindManyMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/mobile/bookings/:bookingId — kit images", () => {
+  it("sends a lapsed kit image re-signed, with its new expiry", async () => {
+    findFirstMock.mockResolvedValue(
+      bookingRow([
+        slice({ id: "ba1", assetId: "a1", membership: "ak1", kit: AUDIO }),
+      ])
+    );
+    const storedKit = {
+      ...AUDIO,
+      organizationId: "org-1",
+      status: "AVAILABLE",
+      image: "https://example.test/sign/kits/audio.png?token=lapsed",
+      imageExpiration: new Date("2020-01-01T00:00:00.000Z"),
+      category: null,
+      location: null,
+      _count: { assetKits: 1 },
+    };
+    kitFindManyMock.mockResolvedValueOnce([storedKit] as never);
+    const resignedImage =
+      "https://example.test/sign/kits/audio.png?token=fresh";
+    const newExpiration = new Date("2099-01-01T00:00:00.000Z");
+    refreshExpiredKitImagesMock.mockResolvedValueOnce([
+      { ...storedKit, image: resignedImage, imageExpiration: newExpiration },
+    ]);
+
+    const kits = kitsFrom(await get());
+
+    // The rows go to the helper as the query returned them — `organizationId`
+    // included, since the helper scopes its write-back by it.
+    expect(refreshExpiredKitImagesMock).toHaveBeenCalledWith([storedKit]);
+    expect(kits[0]).toMatchObject({
+      id: "kit-audio",
+      image: resignedImage,
+      imageExpiration: newExpiration,
+      assetCount: 1,
+    });
+    // Selected for the write-back only; the app's kit shape has no such field.
+    expect(kits[0]).not.toHaveProperty("organizationId");
   });
 });
 

--- a/apps/webapp/test/routes-tests/api+/mobile+/kits.$kitId.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/kits.$kitId.test.ts
@@ -1,12 +1,15 @@
 /**
- * Regression tests for the mobile kit detail endpoint.
+ * Response-contract tests for the mobile kit detail endpoint.
  *
- * Pins the Gap-3 (kit quantity awareness) contract: each `kit.assets[]`
- * member must additively carry `kitQuantity` (= `AssetKit.quantity`, the
- * units of that asset held by THIS kit), `unitOfMeasure`, and `type`. It also
- * pins the `totalValue` correctness fix — the kit-surface multiplier is the
- * per-membership `AssetKit.quantity`, NOT the asset's workspace-wide
- * `Asset.quantity` stock (see .claude/rules/quantity-semantics-per-surface.md).
+ * - Each `kit.assets[]` member carries `kitQuantity` (= `AssetKit.quantity`,
+ *   the units of that asset held by THIS kit), `unitOfMeasure`, and `type`.
+ * - `totalValue` multiplies by the per-membership `AssetKit.quantity`, NOT the
+ *   asset's workspace-wide `Asset.quantity` stock (see
+ *   .claude/rules/quantity-semantics-per-surface.md).
+ * - Custody is nulled for a viewer who may not see the holder.
+ * - The kit's `image` is a signed URL the app cannot renew, so the kit goes
+ *   through `refreshExpiredKitImages` before it is sent: a lapsed URL arrives
+ *   re-signed, with the `imageExpiration` the helper returned.
  *
  * @see {@link file://../../../../app/routes/api+/mobile+/kits.$kitId.ts} for the loader under test
  */
@@ -21,6 +24,7 @@ import {
   requireOrganizationAccess,
   getMobileUserContext,
 } from "~/modules/api/mobile-auth.server";
+import { refreshExpiredKitImages } from "~/modules/kit/service.server";
 
 import { loader } from "~/routes/api+/mobile+/kits.$kitId";
 
@@ -49,11 +53,19 @@ vi.mock("~/modules/api/mobile-auth.server", () => ({
   getMobileUserContext: vi.fn(),
 }));
 
+// why: re-signing calls Supabase Storage and writes the new URL back to the
+// kit row. The helper has its own contract; the kit-image case below pins what
+// the route does with it, and every other case gets its kit back untouched.
+vi.mock("~/modules/kit/service.server", () => ({
+  refreshExpiredKitImages: vi.fn((kits: unknown[]) => Promise.resolve(kits)),
+}));
+
 const findFirstMock = vi.mocked(db.kit.findFirst);
 const requireMobileAuthMock = vi.mocked(requireMobileAuth);
 const requireOrganizationAccessMock = vi.mocked(requireOrganizationAccess);
 const requireMobilePermissionMock = vi.mocked(requireMobilePermission);
 const getMobileUserContextMock = vi.mocked(getMobileUserContext);
+const refreshExpiredKitImagesMock = vi.mocked(refreshExpiredKitImages);
 
 const FAKE_USER_ID = "user-abc";
 const FAKE_ORG_ID = "org-xyz";
@@ -178,6 +190,41 @@ describe("GET /api/mobile/kits/:kitId", () => {
   });
 });
 
+describe("GET /api/mobile/kits/:kitId — kit image", () => {
+  it("sends a lapsed kit image re-signed, with its new expiry", async () => {
+    const storedKit = {
+      ...buildKitFixture([]),
+      organizationId: FAKE_ORG_ID,
+      image: "https://example.test/sign/kits/camera.png?token=lapsed",
+      imageExpiration: new Date("2020-01-01T00:00:00.000Z"),
+    };
+    findFirstMock.mockResolvedValueOnce(storedKit as never);
+    const resignedImage =
+      "https://example.test/sign/kits/camera.png?token=fresh";
+    const newExpiration = new Date("2099-01-01T00:00:00.000Z");
+    refreshExpiredKitImagesMock.mockResolvedValueOnce([
+      { ...storedKit, image: resignedImage, imageExpiration: newExpiration },
+    ]);
+
+    const response = await loader(
+      createLoaderArgs({ params: { kitId: "kit-1" } })
+    );
+    assertIsDataWithResponseInit(response);
+    const body = response.data as { kit: Record<string, unknown> };
+
+    // The kit goes to the helper as the query returned it — `organizationId`
+    // included, since the helper scopes its write-back by it.
+    expect(refreshExpiredKitImagesMock).toHaveBeenCalledWith([storedKit]);
+    expect(body.kit).toMatchObject({
+      id: "kit-1",
+      image: resignedImage,
+      imageExpiration: newExpiration,
+    });
+    // Selected for the write-back only; the app's kit shape has no such field.
+    expect(body.kit).not.toHaveProperty("organizationId");
+  });
+});
+
 describe("GET /api/mobile/kits/:kitId — custody visibility", () => {
   /** Kit fixture holding custody by a named colleague, with their email. */
   function kitInColleaguesCustody() {
@@ -201,7 +248,7 @@ describe("GET /api/mobile/kits/:kitId — custody visibility", () => {
 
   it("nulls a colleague's custody for a viewer who may not see all custody", async () => {
     // `kit: read` is held by BASE and SELF_SERVICE, and this select reaches
-    // `custodian.user.email` — so without a gate the whole identity shipped.
+    // `custodian.user.email` — without the gate the whole identity is sent.
     getMobileUserContextMock.mockResolvedValue({
       canSeeAllCustody: false,
     } as Awaited<ReturnType<typeof getMobileUserContext>>);

--- a/apps/webapp/test/routes-tests/api+/mobile+/kits.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/kits.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Response-contract tests for the mobile kits list endpoint.
+ *
+ * A kit's `image` is a signed URL with a lifetime, and the companion's kits
+ * list renders it as sent. So every kit on the page goes through
+ * `refreshExpiredKitImages` before the response is shaped: a lapsed URL
+ * arrives re-signed, with the `imageExpiration` the helper returned, and
+ * `organizationId` (selected only to scope the helper's write-back) stays out
+ * of the payload.
+ *
+ * @see {@link file://../../../../app/routes/api+/mobile+/kits.ts} for the loader under test
+ * @see {@link file://../../../../app/modules/kit/service.server.ts} for `refreshExpiredKitImages`
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createLoaderArgs } from "@mocks/remix";
+
+import { db } from "~/database/db.server";
+import {
+  getMobileUserContext,
+  requireMobileAuth,
+  requireMobilePermission,
+  requireOrganizationAccess,
+} from "~/modules/api/mobile-auth.server";
+import { refreshExpiredKitImages } from "~/modules/kit/service.server";
+
+import { loader } from "~/routes/api+/mobile+/kits";
+
+import { assertIsDataWithResponseInit } from "@helpers/assertions";
+
+// @vitest-environment node
+
+// why: db is the integration boundary — the loader reads one page of kits and
+// the total count, and the test inspects the response shaped from them.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    kit: { findMany: vi.fn(), count: vi.fn() },
+  },
+}));
+
+// why: `mobile-auth.server` transitively loads the Supabase admin client and
+// the real Prisma client (no DB / env in unit tests). The route only calls
+// these four gate functions, so only those are stubbed.
+vi.mock("~/modules/api/mobile-auth.server", () => ({
+  requireMobileAuth: vi.fn(),
+  requireOrganizationAccess: vi.fn(),
+  requireMobilePermission: vi.fn(),
+  getMobileUserContext: vi.fn(),
+}));
+
+// why: re-signing calls Supabase Storage and writes the new URL back to the
+// kit row. The helper has its own contract; this suite pins what the route
+// does with it: hand over the page's rows, and send what comes back.
+vi.mock("~/modules/kit/service.server", () => ({
+  refreshExpiredKitImages: vi.fn((kits: unknown[]) => Promise.resolve(kits)),
+}));
+
+const findManyMock = vi.mocked(db.kit.findMany);
+const countMock = vi.mocked(db.kit.count);
+const requireMobileAuthMock = vi.mocked(requireMobileAuth);
+const requireOrganizationAccessMock = vi.mocked(requireOrganizationAccess);
+const requireMobilePermissionMock = vi.mocked(requireMobilePermission);
+const getMobileUserContextMock = vi.mocked(getMobileUserContext);
+const refreshExpiredKitImagesMock = vi.mocked(refreshExpiredKitImages);
+
+const FAKE_USER_ID = "user-abc";
+const FAKE_ORG_ID = "org-xyz";
+
+/** One kit row as the list query selects it; override per test. */
+function storedKit(overrides: {
+  id: string;
+  image: string | null;
+  imageExpiration: Date | null;
+}) {
+  return {
+    organizationId: FAKE_ORG_ID,
+    name: `Kit ${overrides.id}`,
+    status: "AVAILABLE",
+    _count: { assetKits: 2 },
+    category: null,
+    location: null,
+    custody: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  requireMobileAuthMock.mockResolvedValue({
+    user: { id: FAKE_USER_ID },
+  } as Awaited<ReturnType<typeof requireMobileAuth>>);
+  requireOrganizationAccessMock.mockResolvedValue(FAKE_ORG_ID);
+  requireMobilePermissionMock.mockResolvedValue(undefined);
+  getMobileUserContextMock.mockResolvedValue({
+    canSeeAllCustody: true,
+  } as Awaited<ReturnType<typeof getMobileUserContext>>);
+});
+
+describe("GET /api/mobile/kits — kit images", () => {
+  it("sends a lapsed kit image re-signed, with its new expiry", async () => {
+    const lapsedKit = storedKit({
+      id: "kit-lapsed",
+      image: "https://example.test/sign/kits/lapsed.png?token=lapsed",
+      imageExpiration: new Date("2020-01-01T00:00:00.000Z"),
+    });
+    const signedKit = storedKit({
+      id: "kit-signed",
+      image: "https://example.test/sign/kits/signed.png?token=valid",
+      imageExpiration: new Date("2099-01-01T00:00:00.000Z"),
+    });
+    findManyMock.mockResolvedValueOnce([lapsedKit, signedKit] as never);
+    countMock.mockResolvedValueOnce(2);
+    const resignedImage =
+      "https://example.test/sign/kits/lapsed.png?token=fresh";
+    const newExpiration = new Date("2099-01-04T00:00:00.000Z");
+    refreshExpiredKitImagesMock.mockResolvedValueOnce([
+      { ...lapsedKit, image: resignedImage, imageExpiration: newExpiration },
+      signedKit,
+    ]);
+
+    const response = await loader(
+      createLoaderArgs({
+        request: new Request("http://localhost:3000/api/mobile/kits"),
+      })
+    );
+    assertIsDataWithResponseInit(response);
+    const body = response.data as { kits: Array<Record<string, unknown>> };
+
+    // The page goes to the helper as the query returned it — `organizationId`
+    // included, since the helper scopes its write-back by it.
+    expect(refreshExpiredKitImagesMock).toHaveBeenCalledWith([
+      lapsedKit,
+      signedKit,
+    ]);
+    expect(body.kits[0]).toMatchObject({
+      id: "kit-lapsed",
+      image: resignedImage,
+      imageExpiration: newExpiration,
+      // The rest of the shaping still applies to the re-signed row.
+      _count: { assets: 2 },
+    });
+    expect(body.kits[1]).toMatchObject({
+      id: "kit-signed",
+      image: signedKit.image,
+      imageExpiration: signedKit.imageExpiration,
+    });
+    // Selected for the write-back only; the app's kit shape has no such field.
+    for (const kit of body.kits) {
+      expect(kit).not.toHaveProperty("organizationId");
+    }
+  });
+});


### PR DESCRIPTION
## What goes wrong

A kit's `image` column holds a Supabase **signed** URL. Upload signs it for 24 hours (`kit/service.server.ts`, `imageExpiration: oneDayFromNow()`), and nothing on the mobile path renews it. Once it lapses, the companion shows:

- **Booking screen:** the kit header checks `imageExpiration` and deliberately hides a lapsed image, so the kit shows the placeholder icon.
- **Kits list and kit detail:** these render the lapsed URL as sent, storage refuses it, and the picture is blank.

## Fix

The three mobile loaders now pass their kit rows through the existing `refreshExpiredKitImages` helper (`apps/webapp/app/modules/kit/service.server.ts`, already used by the reports module) before shaping the response:

| Route | Rows re-signed |
| --- | --- |
| `GET /api/mobile/bookings/:bookingId` | the `booking.kits` rows |
| `GET /api/mobile/kits` | the page of kits |
| `GET /api/mobile/kits/:kitId` | the kit |

The helper re-signs only rows whose `imageExpiration` has passed, in batches of 10. It writes the new URL and a 72-hour expiry back to the kit row, scoped by `organizationId`, and keeps the stale row if a refresh fails.

`organizationId` is added to each kit select for that write-back and dropped before the response. The payload shape does not change: `image` and `imageExpiration` are still sent, now fresh. The booking header's expiry gate stays and now sees a future date.

**No app change.** Every installed build gets fresh URLs on its next request.

A second commit rewrites comments in the three route files so they describe the code as it is, per `.claude/rules/comments-describe-code-not-history.md`. It removes phase names, accounts of earlier fixes and a stale line reference.

## Tests

- `test/routes-tests/api+/mobile+/bookings.$bookingId.kits.test.ts`: new kit-image case.
- `test/routes-tests/api+/mobile+/kits.$kitId.test.ts`: new kit-image case.
- `test/routes-tests/api+/mobile+/kits.test.ts`: new file for the list route.

Each case feeds a kit whose `imageExpiration` is in the past and mocks the helper. It asserts that the loader hands the helper the queried rows, `organizationId` included, and sends back what the helper returned, without `organizationId`. All three cases fail against `main`'s routes and pass on this branch.

- Route test files: 7 files, 29 tests pass.
- Full webapp suite: 465 files, 6,154 tests pass.
- Lint: 0 errors. Typecheck: clean.

## Heads-up for merge order

Trial merges with `git merge-tree` against the two open PRs that touch these files:

- **#3025** also edits `kits.$kitId.ts`. Both PRs add an import after the same line, so whichever lands second resolves a one-line import conflict. Nothing else overlaps.
- **#2980** already conflicts with `main` on the import block of `bookings.$bookingId.ts`. This branch adds one import line to that same hunk and no new conflicts.

## Out of scope

Asset images (a separate path), the app's expiry gate, a client-side refresh route, thumbnails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Mobile kit images now automatically refresh when their secure viewing links expire.
  - Refreshed images are available in kit lists, kit details, and booking details without requiring manual intervention.
  - Kit responses continue to display the expected information while excluding internal organization details.

- **Tests**
  - Added coverage for image-link renewal across mobile kit and booking endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->