### PR TITLE
fix(webapp): make pnpm webapp:validate pass under load

### DIFF
--- a/apps/webapp/app/database/db.server.ts
+++ b/apps/webapp/app/database/db.server.ts
@@ -23,7 +23,11 @@ if (NODE_ENV === "production") {
     global.__db__ = createDatabaseClient();
   }
   db = global.__db__;
-  void db.$connect();
+  // Tests run with placeholder database URLs (see `test/setup-test-env.ts`),
+  // so an eager connect there can only fail, as a late unhandled rejection
+  // that Vitest pins on whichever file happens to be running. Skipping it is
+  // safe: Prisma connects lazily on the first query.
+  if (!process.env.VITEST) void db.$connect();
 }
 
 export { db };

--- a/apps/webapp/vitest.config.ts
+++ b/apps/webapp/vitest.config.ts
@@ -12,15 +12,18 @@ export default defineConfig({
     globals: true,
     environment: "happy-dom",
     setupFiles: ["./test/setup-test-env.ts"],
+    // Route tests import whole route modules inside `beforeAll`, and
+    // `pnpm webapp:validate` runs this suite beside lint and typecheck. Under
+    // that load a cold route import can outlast Vitest's 10-second hook
+    // default. Tests keep the default `testTimeout`, so a slow test body still
+    // fails fast.
+    hookTimeout: 30_000,
     // Route tests live in `test/routes-tests/`, NEVER under `app/routes/` —
     // the dev server warms every file under `app/routes/` as a client module,
     // so a co-located route test importing a `*.server` module breaks
     // `pnpm webapp:dev`. Enforced by `local-rules/no-test-files-in-routes`.
-    // A `**/*.test.server.[jt]s` pattern used to sit alongside this one for
-    // the co-located variant. No `.test.server.*` file remains — route ones
-    // moved to `test/routes-tests/`, the single module one was renamed to
-    // `.test.ts` — so it is gone. Do NOT reintroduce the spelling: it is not
-    // matched by the pattern below, so such a file is silently never run.
+    // Do not name a test `*.test.server.ts`: the pattern below does not match
+    // that spelling, so such a file would silently never run.
     include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
     includeSource: ["app/**/*.{js,ts}"],
     exclude: [


### PR DESCRIPTION
## Summary

`pnpm webapp:validate` fails on `main` for two reasons that have nothing to do with any branch. This PR removes both. No test file changes.

CI stayed green throughout because its Vitest job runs the suite alone, without lint and typecheck competing for the machine.

## Root causes and fixes

**1. Unhandled Prisma rejection** (`fix(db)`, 1c0a9e473). Outside production, `app/database/db.server.ts` calls `db.$connect()` at import time without awaiting it, and under Vitest the database URLs are placeholders from `test/setup-test-env.ts`, so every test file that loads the real module (directly or through the code under test) starts a connect that can only fail. Vitest reports that late P1001 rejection as an unhandled error against whichever file is running when it lands and exits 1; whether it lands before that file's worker exits is a race, which is why it looks flaky.

The eager connect now runs only when `process.env.VITEST` is unset. Prisma connects lazily on the first query, so the dev server and production are unaffected.

**2. Hook timeout on route imports** (`test(webapp)`, 073b9cd8c). Route tests import whole route modules inside `beforeAll`, and `validate` runs Vitest beside ESLint and `tsc` through `run-p`. Under that load a cold route import can outlast Vitest's 10-second default hook timeout.

`vitest.config.ts` now sets `hookTimeout: 30_000`. `testTimeout` keeps its default, so a slow test body still fails fast. The include-pattern comment in the same file now states its rule without the history of the file.

## Proof

**Before:** `main` @ e894dbc08, `pnpm webapp:validate`, exit 1 after 232 s.

```text
 FAIL  test/routes-tests/_layout+/assets.$assetId.activity[.csv].test.ts
 FAIL  test/routes-tests/_layout+/bookings.$bookingId.activity[.csv].test.ts
Error: Hook timed out in 10000ms.

⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
PrismaClientInitializationError: Can't reach database server at `{HOST}:6543`
Serialized Error: { clientVersion: '6.19.3', errorCode: 'P1001', retryable: undefined }
This error originated in "app/modules/kit/picker-meta.server.test.ts" test file.

 Test Files  2 failed | 462 passed (464)
      Tests  6144 passed | 8 skipped | 1 todo (6153)
     Errors  1 error
```

**Mechanism check.** A throwaway test (not committed) imports the real client and waits 4 seconds, long enough for an eager connect to fail:

| Build | Tests | Vitest errors | Exit |
| --- | --- | --- | --- |
| `main` | 1 passed | 1 (Unhandled Rejection, P1001) | 1 |
| this branch | 1 passed | 0 | 0 |

**After:** this branch @ 073b9cd8c, three consecutive `pnpm webapp:validate` runs on the same 8-core laptop, which other work was also loading. The 1-minute load average at the start of each run is shown for context.

| Run | Exit | Wall time | Load average at start | "Unhandled" lines | "Hook timed out" lines |
| --- | --- | --- | --- | --- | --- |
| 1 | 0 | 227 s | 9.9 | 0 | 0 |
| 2 | 0 | 160 s | 65.2 | 0 | 0 |
| 3 | 0 | 227 s | 92.4 | 0 | 0 |

Each run: `Test Files 464 passed (464)`, `Tests 6151 passed | 1 skipped | 1 todo`, ESLint 0 errors, typecheck clean.

`pnpm --filter @shelf/webapp test -- --run` (the CI command): exit 0 in 111 s, 464 of 464 files passed, 0 "Unhandled" lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability by preventing unnecessary database connections during test runs.
  * Increased the time allowed for test setup and teardown hooks, reducing failures caused by slow initialization or cleanup.

* **Documentation**
  * Updated testing guidance to clarify supported test file naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->