### PR TITLE
feat(companion): show booked assets' locations and search the booking list

### DIFF
--- a/apps/companion/.maestro/flows/bookings/19-asset-locations-and-search.yaml
+++ b/apps/companion/.maestro/flows/bookings/19-asset-locations-and-search.yaml
@@ -1,0 +1,254 @@
+appId: com.shelf.companion.carlos
+name: "Bookings - Asset locations and the assets search (mobile) [FIXTURE-DEPENDENT]"
+tags:
+  - bookings
+  - kits
+  - search
+  - fixture-dependent
+env:
+  BOOKING_NAME: "ZZX Stress"
+  AUDIO_KIT: "ZZX Audio Package"
+  RIG_KIT: "ZZX Projection Rig"
+  KIT_LOCATION: "Studio"
+  PLACED_ASSET: "ZZX Standalone Fixture 01"
+  PLACED_ASSET_LOCATION: "Mobile Lab 2"
+
+---
+# Each asset row names where it sits, kit members included, and the search box
+# above the list narrows it by name, kit and location without touching the
+# selection.
+#
+# Precondition: app foregrounded with a signed-in session (qa-admin1 /
+# GRANULAR WORKSPACE). Uses the no-login pattern, so NO launchApp/clearState.
+# Fixture (QA database): the RESERVED booking whose name starts "ZZX Stress",
+# holding "ZZX Audio Package" (3 of 3, the kit placed at "Studio", which places
+# its members there too), "ZZX Projection Rig" (4 of 4, unplaced) and
+# standalone fixtures, of which only "ZZX Standalone Fixture 01" is placed, at
+# "Mobile Lab 2".
+#
+# Read-only: it opens a selection mode and picks rows, then cancels. Nothing is
+# submitted, so the fixture booking is unchanged.
+#
+# An asset row's accessibility label reads "<title>, at <location>, <status>…",
+# which is what the location assertions read. Maestro full-matches labels, so
+# text matchers are regex-wrapped with .* per .maestro/LESSONS.md.
+
+# ── Open the fixture booking ──
+# A second tap on the active tab returns its stack to the list.
+- tapOn: "Bookings"
+- tapOn:
+    text: "Bookings"
+    optional: true
+- extendedWaitUntil:
+    visible: "Search bookings"
+    timeout: 20000
+- tapOn: "Search bookings"
+- eraseText: 40
+- inputText: "${BOOKING_NAME}"
+- extendedWaitUntil:
+    visible: "Booking: ${BOOKING_NAME}.*"
+    timeout: 20000
+# The first tap may only close the keyboard.
+- tapOn: "Booking: ${BOOKING_NAME}.*"
+- tapOn:
+    text: "Booking: ${BOOKING_NAME}.*"
+    optional: true
+- extendedWaitUntil:
+    visible: ".*Select assets to remove.*"
+    timeout: 30000
+
+# ── Kit members and standalone assets carry their location ──
+- scrollUntilVisible:
+    element:
+      text: "Kit: ${AUDIO_KIT}, 3 assets,.*collapsed.*"
+    direction: DOWN
+    timeout: 30000
+    waitToSettleTimeoutMs: 600
+    centerElement: true
+- tapOn: "Kit: ${AUDIO_KIT}, 3 assets,.*collapsed.*"
+- extendedWaitUntil:
+    visible: "Kit: ${AUDIO_KIT}, 3 assets,.*expanded.*"
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      text: "${PLACED_ASSET}, at ${PLACED_ASSET_LOCATION},.*"
+    direction: DOWN
+    timeout: 20000
+    waitToSettleTimeoutMs: 600
+- assertVisible: "${AUDIO_KIT} — item 3, at ${KIT_LOCATION},.*"
+- takeScreenshot: 01-locations-on-kit-members-and-standalone
+
+# ── A kit's name narrows the list to that kit ──
+- scrollUntilVisible:
+    element:
+      text: "Search assets and kits"
+    direction: UP
+    timeout: 20000
+    centerElement: true
+- tapOn: "Search assets and kits"
+- inputText: "audio package"
+# Return closes the keyboard, so the rows it found are all on screen.
+- pressKey: Enter
+- extendedWaitUntil:
+    visible: "Kit: ${AUDIO_KIT}, 3 assets,.*"
+    timeout: 10000
+- assertNotVisible: "Kit: ${RIG_KIT}.*"
+- assertNotVisible: "${PLACED_ASSET},.*"
+- assertVisible: "${AUDIO_KIT} — item 1, at ${KIT_LOCATION},.*"
+- takeScreenshot: 02-search-by-kit-name
+
+# ── A location's name finds what sits there ──
+- tapOn: "Clear search"
+- tapOn: "Search assets and kits"
+- inputText: "mobile lab"
+- pressKey: Enter
+- extendedWaitUntil:
+    visible: "${PLACED_ASSET}, at ${PLACED_ASSET_LOCATION},.*"
+    timeout: 10000
+- assertNotVisible: "Kit: ${AUDIO_KIT}.*"
+- assertNotVisible: "Kit: ${RIG_KIT}.*"
+- takeScreenshot: 03-search-by-location
+
+# ── A term that matches nothing says so ──
+- tapOn: "Clear search"
+- tapOn: "Search assets and kits"
+- inputText: "zzqq"
+- pressKey: Enter
+- extendedWaitUntil:
+    visible: "No assets match.*"
+    timeout: 10000
+- takeScreenshot: 04-search-no-match
+- tapOn: "Clear search"
+- extendedWaitUntil:
+    visible: "Kit: ${RIG_KIT}.*"
+    timeout: 10000
+
+# ── The selection survives a change of term ──
+- scrollUntilVisible:
+    element:
+      text: "Select assets to remove"
+    direction: UP
+    timeout: 30000
+    centerElement: true
+- tapOn: "Select assets to remove"
+- extendedWaitUntil:
+    visible: "Cancel selection"
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      text: "${PLACED_ASSET}, at ${PLACED_ASSET_LOCATION},.*Tap to select.*"
+    direction: DOWN
+    timeout: 30000
+    waitToSettleTimeoutMs: 600
+    centerElement: true
+- tapOn: "${PLACED_ASSET}, at ${PLACED_ASSET_LOCATION},.*Tap to select.*"
+- extendedWaitUntil:
+    visible: ".*Remove 1 selected assets.*"
+    timeout: 10000
+# A term that hides the selected row leaves it selected.
+- scrollUntilVisible:
+    element:
+      text: "Search assets and kits"
+    direction: UP
+    timeout: 20000
+    centerElement: true
+- tapOn: "Search assets and kits"
+- inputText: "audio package"
+- pressKey: Enter
+- extendedWaitUntil:
+    visible: "Kit: ${AUDIO_KIT}, 3 assets,.*"
+    timeout: 10000
+- assertNotVisible: "${PLACED_ASSET},.*"
+- assertVisible: ".*Remove 1 selected assets.*"
+# The kit header picks its three members; the count adds them to the hidden one.
+- tapOn: "Kit: ${AUDIO_KIT}, 3 assets,.*Tap to select.*"
+- extendedWaitUntil:
+    visible: ".*Remove 4 selected assets.*"
+    timeout: 10000
+- takeScreenshot: 05-selection-kept-across-search
+# Clearing the term shows the hidden row still selected.
+- tapOn: "Clear search"
+- scrollUntilVisible:
+    element:
+      text: "${PLACED_ASSET}, at ${PLACED_ASSET_LOCATION},.*selected.*"
+    direction: DOWN
+    timeout: 30000
+    waitToSettleTimeoutMs: 600
+    centerElement: true
+- assertVisible: ".*Remove 4 selected assets.*"
+- takeScreenshot: 06-selection-after-clearing-search
+
+# ── A kit found through one member selects all of its members ──
+# "item 3" is in one member title of each kit and in nothing else, so both kits
+# are on screen only because of that member; the rest come back with it.
+- scrollUntilVisible:
+    element:
+      text: "Search assets and kits"
+    direction: UP
+    timeout: 20000
+    centerElement: true
+- tapOn: "Search assets and kits"
+- inputText: "item 3"
+- pressKey: Enter
+- extendedWaitUntil:
+    visible: "Kit: ${RIG_KIT}, 4 assets,.*Tap to select.*"
+    timeout: 10000
+- assertNotVisible: "${PLACED_ASSET},.*"
+- tapOn: "Kit: ${RIG_KIT}, 4 assets,.*Tap to select.*"
+- extendedWaitUntil:
+    visible: ".*Remove 8 selected assets.*"
+    timeout: 10000
+- assertVisible: "${RIG_KIT} — item 1, Available, selected.*"
+- takeScreenshot: 07-kit-found-through-one-member-selected
+# With the term cleared, every member of that kit is selected.
+- tapOn: "Clear search"
+- scrollUntilVisible:
+    element:
+      text: "${RIG_KIT} — item 4, Available, selected.*"
+    direction: DOWN
+    timeout: 30000
+    waitToSettleTimeoutMs: 600
+- assertVisible: "${RIG_KIT} — item 1, Available, selected.*"
+- assertVisible: "${RIG_KIT} — item 2, Available, selected.*"
+- assertVisible: "${RIG_KIT} — item 3, Available, selected.*"
+- assertVisible: ".*Remove 8 selected assets.*"
+- takeScreenshot: 08-every-member-selected-after-clearing
+
+# ── Leaving the selection keeps the term; nothing is submitted ──
+- scrollUntilVisible:
+    element:
+      text: "Search assets and kits"
+    direction: UP
+    timeout: 20000
+    centerElement: true
+- tapOn: "Search assets and kits"
+- inputText: "audio package"
+- pressKey: Enter
+- extendedWaitUntil:
+    notVisible: "Kit: ${RIG_KIT}.*"
+    timeout: 10000
+- scrollUntilVisible:
+    element:
+      text: "Cancel selection"
+    direction: UP
+    timeout: 30000
+    centerElement: true
+- tapOn: "Cancel selection"
+- extendedWaitUntil:
+    notVisible: ".*Remove 8 selected assets.*"
+    timeout: 10000
+# The term outlives the selection mode: the list is still narrowed to the kit
+# and the clear control still shows.
+- scrollUntilVisible:
+    element:
+      text: "Kit: ${AUDIO_KIT}, 3 assets,.*"
+    direction: DOWN
+    timeout: 20000
+    centerElement: true
+- assertVisible: "Clear search"
+- assertNotVisible: "Kit: ${RIG_KIT}.*"
+- takeScreenshot: 09-term-kept-after-leaving-selection
+- tapOn: "Clear search"
+- extendedWaitUntil:
+    visible: "Kit: ${RIG_KIT}.*"
+    timeout: 10000

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -154,11 +154,10 @@ export default function BookingDetailScreen() {
    * Mirrors the web's `canUserManageBookingAssets`: closed statuses reject, and
    * a RESTRICTED role may only build its own DRAFT booking.
    *
-   * BASE as well as SELF_SERVICE. The web passes both roles into that helper
-   * (its parameter is named `isSelfService` but every caller hands it
-   * `isBaseOrSelfService`), while this screen tested SELF_SERVICE alone. A BASE
-   * custodian is a custodian at every status, so the add, browse, remove and
-   * fulfil affordances below stayed on past DRAFT for them.
+   * BASE as well as SELF_SERVICE: the web passes both roles into that helper
+   * (its parameter is named `isSelfService`, but every caller hands it
+   * `isBaseOrSelfService`). The add, browse, remove and fulfil affordances
+   * below therefore turn off past DRAFT for both roles.
    */
   const isRestrictedRole = Boolean(
     currentOrg?.roles?.some((r) => r === "SELF_SERVICE" || r === "BASE")
@@ -899,11 +898,11 @@ export default function BookingDetailScreen() {
               pushIntoTab("/(tabs)/assets", `/(tabs)/assets/${item.id}`);
             }
           }}
-          accessibilityLabel={`${item.title}, ${stateLabel}${
-            isCheckedIn ? ", checked in" : ""
-          }${isSelected ? ", selected" : ""}${
-            selectable ? ". Tap to select" : ""
-          }`}
+          accessibilityLabel={`${item.title}${
+            item.location ? `, at ${item.location.name}` : ""
+          }, ${stateLabel}${isCheckedIn ? ", checked in" : ""}${
+            isSelected ? ", selected" : ""
+          }${selectable ? ". Tap to select" : ""}`}
           accessibilityRole="button"
         >
           {selectable && (
@@ -984,6 +983,20 @@ export default function BookingDetailScreen() {
                 {item.category.name}
               </Text>
             )}
+            {/* Kit members carry their own location too, as on the website.
+                An older server sends none, and the row then has no line. */}
+            {item.location ? (
+              <View style={styles.assetLocationRow}>
+                <Ionicons
+                  name="location-outline"
+                  size={11}
+                  color={colors.mutedLight}
+                />
+                <Text style={styles.assetLocation} numberOfLines={1}>
+                  {item.location.name}
+                </Text>
+              </View>
+            ) : null}
           </View>
 
           <View style={[styles.statusBadge, { backgroundColor: badge.bg }]}>
@@ -1103,8 +1116,8 @@ export default function BookingDetailScreen() {
    *
    * The first two are decided from rows this screen already holds. The third
    * cannot be — it needs the overlapping-booking query — so the server sends
-   * it as a flag. `?? false` keeps a not-yet-updated server (rolling deploy,
-   * field absent) on the old behavior rather than blocking Reserve outright.
+   * it as a flag. `?? false` reads a server that does not send the flag
+   * (rolling deploy) as reporting no conflict, rather than blocking Reserve.
    *
    * All three are enforced server-side too: the first two in
    * `bookings.reserve.ts`, the third by `reserveBooking`'s race-safe conflict
@@ -1304,10 +1317,9 @@ export default function BookingDetailScreen() {
                   </View>
                 )}
 
-                {/* why: web shows who created the booking on this same screen,
-                    and the field was already in the payload — fetched, then
-                    dropped. Custodian and creator are different people often
-                    enough that showing only one is misleading. */}
+                {/* why: web shows who created the booking on this same screen.
+                    Custodian and creator are different people often enough
+                    that showing only one is misleading. */}
                 {creatorName ? (
                   <View style={styles.infoRow}>
                     <Ionicons
@@ -1436,11 +1448,10 @@ export default function BookingDetailScreen() {
                 </View>
               </View>
             )}
-            {/* why visible rather than only in an alert: the disabled Reserve
-                  button was a dead control - tapping it produced nothing on
-                  device, so the one thing a user needs (what to fix) was
-                  unreachable. Stating it here does not depend on a tap firing,
-                  and it is readable before you even reach for the button. */}
+            {/* why visible rather than only in an alert: a disabled button
+                  takes no taps, so a reason shown on tap could never appear.
+                  Stating it here does not depend on a tap firing, and it is
+                  readable before you even reach for the button. */}
             {booking.status === "DRAFT" && reserveBlockedReason ? (
               <Text style={styles.reserveBlockedNote}>
                 {reserveBlockedReason}
@@ -2534,6 +2545,19 @@ const useStyles = createStyles((colors, shadows) => ({
   assetCategory: {
     fontSize: fontSize.xs,
     color: colors.muted,
+  },
+  // The location line matches the kit header's, so a kit and the assets under
+  // it name their locations the same way.
+  assetLocationRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 2,
+  },
+  assetLocation: {
+    fontSize: fontSize.xs,
+    color: colors.mutedLight,
+    // Shrinks beside the icon, so a long name truncates inside the card.
+    flexShrink: 1,
   },
 
   // Checkbox for selection

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -16,6 +16,7 @@ import {
   Platform,
   ActionSheetIOS,
   Modal,
+  type LayoutChangeEvent,
 } from "react-native";
 import * as Haptics from "expo-haptics";
 import { Image } from "expo-image";
@@ -50,6 +51,7 @@ import {
 } from "@/components/checkin-disposition-sheet";
 import { announce } from "@/lib/a11y";
 import { maybeAskForReview } from "@/lib/review-prompt";
+import { BookingAssetsSearch } from "@/components/bookings/booking-assets-search";
 import { BookingKitHeader } from "@/components/bookings/booking-kit-header";
 import {
   bookingRowKey,
@@ -62,6 +64,7 @@ import {
   splitRemovalSelection,
   type BookingRow,
 } from "@/lib/booking-kit-rows";
+import { filterBookingAssets } from "@/lib/booking-search";
 
 /**
  * Booking-scoped lifecycle state for a QUANTITY_TRACKED asset row. The asset's
@@ -120,6 +123,12 @@ const LIFECYCLE_COLORS = {
   returned: "#22C55E",
 } as const;
 
+/**
+ * The booking detail screen: the booking's details, the actions its status and
+ * the caller's role allow, its reserved models, and its assets and kits, which
+ * can be searched, grouped under their kits, and selected for check-in,
+ * check-out or removal.
+ */
 export default function BookingDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
@@ -181,6 +190,16 @@ export default function BookingDetailScreen() {
   // Kits open collapsed, as on the website: a booking of several kits should
   // read as a short list of cases, not as every asset inside them.
   const [expandedKitIds, setExpandedKitIds] = useState<Set<string>>(new Set());
+  // What the user typed into the assets search. It narrows what the list shows
+  // and nothing else: the selection, the select modes and the counts above the
+  // list all keep reading the whole booking.
+  const [searchTerm, setSearchTerm] = useState("");
+  const isSearching = searchTerm.trim().length > 0;
+  const listRef = useRef<FlatList<BookingRow>>(null);
+  // The search box's offset from the top of the list's content. The box sits
+  // directly in the list header, which starts the content, so its layout `y`
+  // is that offset.
+  const searchBoxY = useRef(0);
 
   // Sequential quantity picker for checking out QUANTITY_TRACKED assets: the
   // user selects the rows, then we walk each QT asset asking "how many units?"
@@ -780,8 +799,13 @@ export default function BookingDetailScreen() {
   }, []);
 
   /**
-   * The list's rows: one header per kit, its members beneath when open, and
-   * every ungrouped asset where the server put it.
+   * The whole booking as rows: one header per kit, its members beneath when
+   * open, and every ungrouped asset where the server put it.
+   *
+   * Everything that acts on the selection reads these rows, never the searched
+   * ones. A selection made before a search can hold assets the search hides,
+   * and `splitRemovalSelection` has to see all of them to tell a whole kit from
+   * a standalone row.
    */
   const rows = useMemo(
     () =>
@@ -792,6 +816,38 @@ export default function BookingDetailScreen() {
       }),
     [booking?.assets, booking?.kits, expandedKitIds]
   );
+
+  /**
+   * The rows the list shows: the whole booking, or what the search found. A
+   * search returns kits whole, so a kit header here counts, badges and selects
+   * the same members it does in `rows`.
+   */
+  const visibleRows = useMemo(() => {
+    const allAssets = booking?.assets ?? [];
+    const found = filterBookingAssets(allAssets, booking?.kits, searchTerm);
+    if (found === allAssets) return rows;
+    return buildBookingRows({
+      assets: found,
+      kits: booking?.kits,
+      expandedKitIds,
+    });
+  }, [booking?.assets, booking?.kits, expandedKitIds, rows, searchTerm]);
+
+  /**
+   * Scrolls the search box to the top of the list, so the rows it finds fill
+   * the space above the keyboard rather than sitting behind it.
+   */
+  const revealSearchResults = useCallback(() => {
+    listRef.current?.scrollToOffset({
+      offset: Math.max(0, searchBoxY.current - spacing.sm),
+      animated: true,
+    });
+  }, []);
+
+  /** Keeps `searchBoxY` in step with where the search box is laid out. */
+  const recordSearchBoxY = useCallback((event: LayoutChangeEvent) => {
+    searchBoxY.current = event.nativeEvent.layout.y;
+  }, []);
 
   const toggleKitExpansion = useCallback((kitId: string) => {
     setExpandedKitIds((prev) => {
@@ -1224,10 +1280,19 @@ export default function BookingDetailScreen() {
       )}
 
       <FlatList
-        data={rows}
+        ref={listRef}
+        data={visibleRows}
         renderItem={renderRow}
         keyExtractor={bookingRowKey}
         contentContainerStyle={styles.list}
+        // With the search keyboard up, the first tap on a row selects it
+        // instead of only closing the keyboard; scrolling puts it away. On iOS
+        // the keyboard's height is added below the rows, so the search box can
+        // scroll to the top even when few rows match. Android resizes the
+        // window instead, where a short list may stop short of the top.
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="on-drag"
+        automaticallyAdjustKeyboardInsets
         removeClippedSubviews
         maxToRenderPerBatch={10}
         windowSize={5}
@@ -1239,6 +1304,13 @@ export default function BookingDetailScreen() {
             tintColor={colors.muted}
             accessibilityLabel="Pull to refresh"
           />
+        }
+        ListEmptyComponent={
+          isSearching ? (
+            <Text style={styles.searchEmpty}>
+              No assets match &ldquo;{searchTerm.trim()}&rdquo;
+            </Text>
+          ) : null
         }
         ListHeaderComponent={
           <View style={styles.header}>
@@ -1941,6 +2013,19 @@ export default function BookingDetailScreen() {
                 Assets ({booking.assetCount})
               </Text>
             )}
+
+            {/* The booking arrives whole, so the search filters the rows the
+                screen already holds and fetches nothing. The box stays while a
+                term is set, so a term that outlives the last asset can still
+                be cleared. */}
+            {booking.assets.length > 0 || searchTerm !== "" ? (
+              <BookingAssetsSearch
+                value={searchTerm}
+                onChangeText={setSearchTerm}
+                onFocus={revealSearchResults}
+                onLayout={recordSearchBoxY}
+              />
+            ) : null}
           </View>
         }
       />
@@ -2407,6 +2492,12 @@ const useStyles = createStyles((colors, shadows) => ({
     fontSize: fontSize.xs,
     color: colors.muted,
     marginTop: 2,
+  },
+  searchEmpty: {
+    fontSize: fontSize.base,
+    color: colors.muted,
+    textAlign: "center",
+    paddingVertical: spacing.xl,
   },
 
   // Reserved-models (book-by-model) section

--- a/apps/companion/components/bookings/booking-assets-search.tsx
+++ b/apps/companion/components/bookings/booking-assets-search.tsx
@@ -1,0 +1,95 @@
+/**
+ * BookingAssetsSearch — the search box above a booking's assets and kits.
+ *
+ * Drawn like the search box on the assets list: a search glyph, the input,
+ * and a clear control once there is something to clear. It holds no state of
+ * its own; the booking screen owns the term and decides what it filters.
+ *
+ * @see ../../app/(tabs)/bookings/[id].tsx — the only consumer
+ * @see ../../lib/booking-search.ts — what a term finds
+ */
+import { Ionicons } from "@expo/vector-icons";
+import {
+  TextInput,
+  TouchableOpacity,
+  View,
+  type LayoutChangeEvent,
+} from "react-native";
+
+import { borderRadius, fontSize, hitSlop, spacing } from "@/lib/constants";
+import { createStyles } from "@/lib/create-styles";
+import { useTheme } from "@/lib/theme-context";
+
+type BookingAssetsSearchProps = {
+  /** What the user has typed. */
+  value: string;
+  /** Called on every keystroke, and with `""` when the term is cleared. */
+  onChangeText: (text: string) => void;
+  /** Called when the input gains focus. */
+  onFocus?: () => void;
+  /** Reports where the box sits within its parent. */
+  onLayout?: (event: LayoutChangeEvent) => void;
+};
+
+/**
+ * The search box for a booking's assets and kits.
+ *
+ * @param props - see {@link BookingAssetsSearchProps}
+ */
+export function BookingAssetsSearch({
+  value,
+  onChangeText,
+  onFocus,
+  onLayout,
+}: BookingAssetsSearchProps) {
+  const { colors } = useTheme();
+  const styles = useStyles();
+
+  return (
+    <View style={styles.container} onLayout={onLayout}>
+      <Ionicons name="search" size={16} color={colors.mutedLight} />
+      <TextInput
+        style={styles.input}
+        value={value}
+        onChangeText={onChangeText}
+        onFocus={onFocus}
+        placeholder="Search assets & kits"
+        placeholderTextColor={colors.placeholderText}
+        returnKeyType="search"
+        autoCorrect={false}
+        autoCapitalize="none"
+        accessibilityLabel="Search assets and kits"
+      />
+      {value.length > 0 ? (
+        <TouchableOpacity
+          onPress={() => onChangeText("")}
+          hitSlop={hitSlop.md}
+          accessibilityLabel="Clear search"
+          accessibilityRole="button"
+        >
+          <Ionicons name="close-circle" size={16} color={colors.mutedLight} />
+        </TouchableOpacity>
+      ) : null}
+    </View>
+  );
+}
+
+const useStyles = createStyles((colors, shadows) => ({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: colors.white,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderRadius: borderRadius.sm,
+    borderWidth: 1,
+    borderColor: colors.gray300,
+    gap: spacing.sm,
+    ...shadows.sm,
+  },
+  input: {
+    flex: 1,
+    fontSize: fontSize.lg,
+    color: colors.foreground,
+  },
+}));

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -682,6 +682,12 @@ export type BookingAsset = {
   mainImage: string | null;
   kitId: string | null;
   category: { id: string; name: string; color: string } | null;
+  /**
+   * Where the asset sits: its primary placement, or null when it is unplaced.
+   * Optional because an older server does not send it, in which case the row
+   * shows no location line.
+   */
+  location?: { id: string; name: string } | null;
   kit: { id: string; name: string } | null;
   // Quantity-tracked fields. The server sends `quantity` for every asset;
   // `type`/`unitOfMeasure`/`consumptionType` + the `remaining*` counts are what

--- a/apps/companion/lib/booking-search.test.ts
+++ b/apps/companion/lib/booking-search.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for the booking detail screen's search.
+ *
+ * These run under Node's test runner via tsx, so this file and the module it
+ * tests must not import React Native, Expo, or `@/`-aliased paths.
+ *
+ * @see ./booking-search.ts
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { buildBookingRows } from "./booking-kit-rows";
+import { filterBookingAssets } from "./booking-search";
+import type { BookingAsset, BookingKit } from "./api/types";
+
+/**
+ * A booking asset as the endpoint sends it: standalone, uncategorised and
+ * unplaced unless `overrides` says otherwise.
+ */
+function asset(
+  overrides: Partial<BookingAsset> & { id: string }
+): BookingAsset {
+  return {
+    title: `Asset ${overrides.id}`,
+    status: "AVAILABLE",
+    mainImage: null,
+    kitId: null,
+    category: null,
+    kit: null,
+    ...overrides,
+  };
+}
+
+/** An asset booked as a member of `kit`, carrying the kit id and name. */
+function member(
+  overrides: Partial<BookingAsset> & { id: string },
+  kit: BookingKit
+): BookingAsset {
+  return asset({
+    kitId: kit.id,
+    kit: { id: kit.id, name: kit.name },
+    ...overrides,
+  });
+}
+
+/** A kit record as the endpoint sends it in `booking.kits`, without an image. */
+function kitRecord(
+  overrides: Partial<BookingKit> & { id: string; name: string }
+): BookingKit {
+  return {
+    status: "AVAILABLE",
+    image: null,
+    imageExpiration: null,
+    category: null,
+    location: null,
+    assetCount: 3,
+    ...overrides,
+  };
+}
+
+const cameraKit = kitRecord({
+  id: "kit-camera",
+  name: "Camera Kit",
+  category: { id: "cat-video", name: "Video", color: "#000000" },
+  location: { id: "loc-cage", name: "Equipment Cage" },
+});
+
+const audioKit = kitRecord({ id: "kit-audio", name: "Audio Package" });
+
+const tripod = asset({
+  id: "tripod",
+  title: "Carbon Tripod",
+  category: { id: "cat-support", name: "Support", color: "#111111" },
+  location: { id: "loc-store", name: "Main Store" },
+});
+const light = asset({
+  id: "light",
+  title: "LED Panel",
+  location: { id: "loc-van", name: "Van 2" },
+});
+const body = member({ id: "body", title: "Mirrorless Body" }, cameraKit);
+const lens = member({ id: "lens", title: "Zoom Lens" }, cameraKit);
+const battery = member({ id: "battery", title: "Spare Battery" }, cameraKit);
+const mic = member({ id: "mic", title: "Shotgun Mic" }, audioKit);
+
+const assets = [tripod, body, light, lens, mic, battery];
+const kits = [cameraKit, audioKit];
+
+/** The ids a search of `list`, with the booking's kits, returns in order. */
+function idsFound(term: string, list: BookingAsset[] = assets) {
+  return filterBookingAssets(list, kits, term).map((a) => a.id);
+}
+
+// ---------------------------------------------------------------------------
+// What a term finds
+// ---------------------------------------------------------------------------
+
+test("a blank term returns the list itself", () => {
+  assert.equal(filterBookingAssets(assets, kits, ""), assets);
+  assert.equal(filterBookingAssets(assets, kits, "   "), assets);
+});
+
+test("a title matches in any case, with the term trimmed", () => {
+  assert.deepEqual(idsFound("  carbon TRIPOD "), ["tripod"]);
+});
+
+test("an asset's category finds it", () => {
+  assert.deepEqual(idsFound("support"), ["tripod"]);
+});
+
+test("an asset's own location finds it", () => {
+  assert.deepEqual(idsFound("van 2"), ["light"]);
+});
+
+test("a kit's name brings back every member of the kit", () => {
+  assert.deepEqual(idsFound("camera kit"), ["body", "lens", "battery"]);
+});
+
+test("a kit's location finds its members, as the kit header shows it", () => {
+  // No member carries a location of its own here; the kit record does.
+  assert.deepEqual(idsFound("equipment cage"), ["body", "lens", "battery"]);
+});
+
+test("a kit's category finds its members", () => {
+  assert.deepEqual(idsFound("video"), ["body", "lens", "battery"]);
+});
+
+test("one member's title brings back the whole kit", () => {
+  // A kit is one thing on this screen: it comes back whole or not at all.
+  assert.deepEqual(idsFound("zoom lens"), ["body", "lens", "battery"]);
+});
+
+test("results keep the server's order", () => {
+  // "o" is in every asset here but the LED panel (for the spare battery, only
+  // in its kit's category), and they come back in the order they were sent.
+  assert.deepEqual(idsFound("o"), ["tripod", "body", "lens", "mic", "battery"]);
+});
+
+test("a term that matches nothing returns an empty list", () => {
+  assert.deepEqual(idsFound("projector"), []);
+});
+
+test("a kit named on a slice finds an asset that stands on its own", () => {
+  // A quantity-tracked asset booked standalone AND through a kit has no single
+  // kit (`kitId: null`) but lists each slice's kit on its row.
+  const cables = asset({
+    id: "cables",
+    title: "XLR Cable",
+    type: "QUANTITY_TRACKED",
+    slices: [
+      { bookingAssetId: "ba-1", quantity: 4, assetKitId: null, kit: null },
+      {
+        bookingAssetId: "ba-2",
+        quantity: 2,
+        assetKitId: "ak-9",
+        kit: { id: "kit-audio", name: "Audio Package" },
+      },
+    ],
+  });
+
+  // Found by the kit it names, alongside that kit's own member; it pulls no
+  // one in, because it belongs to no kit group itself.
+  assert.deepEqual(idsFound("audio package", [...assets, cables]), [
+    "mic",
+    "cables",
+  ]);
+});
+
+// ---------------------------------------------------------------------------
+// Payloads from an older server
+// ---------------------------------------------------------------------------
+
+test("a payload with no location and no kits still searches what it has", () => {
+  // An older server sends neither `location` on assets nor `booking.kits`.
+  const oldPayload: BookingAsset[] = [
+    asset({ id: "tripod", title: "Carbon Tripod" }),
+    member({ id: "body", title: "Mirrorless Body" }, cameraKit),
+    member({ id: "lens", title: "Zoom Lens" }, cameraKit),
+  ];
+  assert.equal("location" in oldPayload[0], false);
+  const found = (term: string) =>
+    filterBookingAssets(oldPayload, undefined, term).map((a) => a.id);
+
+  assert.deepEqual(found("tripod"), ["tripod"]);
+  assert.deepEqual(found("camera kit"), ["body", "lens"]);
+  // Without the kit record, the kit's location is not known.
+  assert.deepEqual(found("equipment cage"), []);
+});
+
+// ---------------------------------------------------------------------------
+// What the list builds from a result
+// ---------------------------------------------------------------------------
+
+test("a found kit's header still counts every member the booking holds", () => {
+  const rows = buildBookingRows({
+    assets: filterBookingAssets(assets, kits, "spare battery"),
+    kits,
+    expandedKitIds: new Set(),
+  });
+
+  assert.equal(rows.length, 1);
+  const [header] = rows;
+  assert.equal(header.type, "kit");
+  assert.deepEqual(header.type === "kit" && header.members.map((m) => m.id), [
+    "body",
+    "lens",
+    "battery",
+  ]);
+});
+
+test("a kit with no member found drops out of the list", () => {
+  const rows = buildBookingRows({
+    assets: filterBookingAssets(assets, kits, "shotgun"),
+    kits,
+    expandedKitIds: new Set(),
+  });
+
+  assert.deepEqual(
+    rows.map((row) => (row.type === "kit" ? `kit:${row.kitId}` : row.type)),
+    ["kit:kit-audio"]
+  );
+});

--- a/apps/companion/lib/booking-search.ts
+++ b/apps/companion/lib/booking-search.ts
@@ -1,0 +1,94 @@
+/**
+ * Search over the assets and kits on the booking detail screen.
+ *
+ * The booking endpoint returns the whole booking in one response, so the phone
+ * searches the rows it already holds rather than asking the server again. An
+ * asset is found by the fields the payload carries: its title, category and
+ * location, the name of its kit or of any kit its units are booked through,
+ * and its kit's location and category.
+ *
+ * This follows the web booking search, `filterBookingAssets` in
+ * `apps/webapp/app/modules/booking/helpers.ts`. It is written against the
+ * mobile payload rather than copied, and it differs in two ways: it cannot see
+ * the fields the phone does not receive (SAM ID, tags, QR and barcode values),
+ * and it matches the term as one string, where the web splits on commas and
+ * reads each part as an alternative.
+ *
+ * A match inside a kit brings the whole kit back, as it does on the web. The
+ * screen treats a kit as one thing: its header counts, badges and selects the
+ * members it holds, and a removal may only name a kit whose members are all on
+ * the list. A search therefore returns a kit whole or not at all.
+ *
+ * Pure and free of React Native so the rules can be tested under Node.
+ *
+ * @see ../app/(tabs)/bookings/[id].tsx — the only consumer
+ * @see ./booking-kit-rows.ts — groups the result into kit and asset rows
+ * @see ../../webapp/app/modules/booking/helpers.ts — the web search
+ */
+import type { BookingAsset, BookingKit } from "./api/types";
+
+/**
+ * The strings an asset can be found by: what its row shows, plus the location
+ * and category its kit header shows above it.
+ *
+ * @param asset - the asset to describe
+ * @param kitsById - the booking's kits, keyed by `Kit.id`
+ * @returns every searchable value, some of them absent
+ */
+function searchableFields(
+  asset: BookingAsset,
+  kitsById: ReadonlyMap<string, BookingKit>
+): (string | null | undefined)[] {
+  const kit = asset.kit ? kitsById.get(asset.kit.id) : undefined;
+  return [
+    asset.title,
+    asset.category?.name,
+    asset.location?.name,
+    asset.kit?.name,
+    kit?.location?.name,
+    kit?.category?.name,
+    // A quantity-tracked asset booked through several kits names each of them
+    // on its row, so a search for any of those kits finds it.
+    ...(asset.slices?.map((slice) => slice.kit?.name) ?? []),
+  ];
+}
+
+/**
+ * The assets a search term finds on a booking.
+ *
+ * Matching is a case-insensitive substring test on the trimmed term. Every
+ * other member of a matching asset's kit comes back with it, keyed on `kitId`
+ * because that is what the list groups by.
+ *
+ * @param assets - the booking's assets, in the order the server sent them
+ * @param kits - the kits sent alongside them; absent from an older server
+ * @param term - what the user typed
+ * @returns the found assets in their original order, or `assets` itself when
+ *   the term is blank, so a memo keyed on the result does not rebuild
+ */
+export function filterBookingAssets(
+  assets: BookingAsset[],
+  kits: BookingKit[] | undefined,
+  term: string
+): BookingAsset[] {
+  const needle = term.trim().toLowerCase();
+  if (!needle) return assets;
+
+  const kitsById = new Map((kits ?? []).map((kit) => [kit.id, kit]));
+  const foundIds = new Set<string>();
+  const foundKitIds = new Set<string>();
+  for (const asset of assets) {
+    const found = searchableFields(asset, kitsById).some(
+      (field) => field != null && field.toLowerCase().includes(needle)
+    );
+    if (!found) continue;
+    foundIds.add(asset.id);
+    if (asset.kitId) foundKitIds.add(asset.kitId);
+  }
+
+  return assets.filter(
+    (asset) =>
+      foundIds.has(asset.id) ||
+      (asset.kitId != null && foundKitIds.has(asset.kitId))
+  );
+}

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
@@ -13,8 +13,10 @@ import {
   getMobileUserContext,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
+import { ASSET_LOCATIONS_INCLUDE } from "~/modules/asset/fields";
 import { serializeAssetImage } from "~/modules/asset/image-resolution";
 import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
+import { getPrimaryLocation } from "~/modules/asset/utils";
 import { computeDispatchedUnitsByAsset } from "~/modules/booking/checkout-attribution";
 import { isBookingArchivable } from "~/modules/booking/helpers";
 import {
@@ -173,6 +175,15 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
                   },
                   orderBy: { createdAt: "asc" },
                 },
+                // Where the asset sits, through the `AssetLocation` pivot.
+                // Only the primary placement is sent (see `location` below),
+                // picked by the shared placement order, so an asset placed in
+                // several locations names the same one on every refresh.
+                assetLocations: {
+                  select: { location: { select: { id: true, name: true } } },
+                  orderBy: ASSET_LOCATIONS_INCLUDE.orderBy,
+                  take: 1,
+                },
               },
             },
           },
@@ -234,9 +245,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     // = mixed standalone + kit-driven). Mobile clients that don't know
     // about `assetKitId` see the same flat shape they always did.
     //
-    // `slices` additively exposes the per-BookingAsset-row breakdown (Gap 1,
-    // Companion QT display parity) so the app can render standalone vs.
-    // kit-driven booked units separately instead of only the merged total.
+    // `slices` additively exposes the per-BookingAsset-row breakdown, so the
+    // app can render standalone vs. kit-driven booked units separately instead
+    // of only the merged total.
     type SliceRow = {
       bookingAssetId: string;
       quantity: number;
@@ -283,7 +294,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     }
 
     const assets = Array.from(byAssetId.values()).map((row) => {
-      const { assetKits, ...rest } = row.first.asset;
+      // `assetLocations` is taken out here so the pivot never reaches the
+      // payload; it is sent only as the flat `location` below.
+      const { assetKits, assetLocations, ...rest } = row.first.asset;
       // why: no `sourceKitId` fallback for detached kit residue here. This
       // response collapses per asset rather than grouping by kit, and the
       // unanimous rule below deliberately reports `null` rather than guessing
@@ -294,10 +307,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       // mis-attribute the slice to one of multiple sources.
       const unanimousAssetKitId =
         row.assetKitIds.size === 1 ? Array.from(row.assetKitIds)[0] : null;
-      // Merged kit = the kit of the unanimous membership, else null. This
-      // REPLACES the legacy `assetKits[0].kit` synthesis, which mislabelled
-      // standalone/mixed rows with an arbitrary membership. Safe for old
-      // clients: they already render a null kit (INDIVIDUAL assets have one).
+      // Merged kit = the kit of the unanimous membership, else null. Never an
+      // arbitrary membership such as `assetKits[0]`: a standalone or mixed row
+      // has no single kit to name. Clients already render a null kit, which
+      // every standalone INDIVIDUAL asset has.
       const mergedKit =
         unanimousAssetKitId != null
           ? assetKits.find((ak) => ak.id === unanimousAssetKitId)?.kit ?? null
@@ -306,6 +319,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         // Resolves the model-image cascade and drops the nested `assetModel`,
         // so the companion keeps one source of truth for the image.
         ...serializeAssetImage(rest),
+        // The asset's primary location, for the location line web's booking
+        // page shows on every asset row, kit members included. `null` when
+        // the asset is unplaced. Additive: older clients ignore it.
+        location: getPrimaryLocation({ assetLocations }),
         kit: mergedKit,
         kitId: mergedKit?.id ?? null,
         // Per-booking quantity (sum of all slices for this asset in
@@ -372,9 +389,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     // Checkinable while ONGOING/OVERDUE AND something is still to check in.
     // INDIVIDUAL: global status CHECKED_OUT. QUANTITY_TRACKED: booked units not
     // yet reconciled = remainingToCheckIn > 0 (booked − returned/consumed/lost/
-    // damaged) — the SAME "remaining" the web check-in drawer caps at. The old
-    // `checkedOutCount > 0` gate hid check-in on a partially-checked-out QT
-    // booking, whose asset status stays AVAILABLE while units are still booked.
+    // damaged) — the SAME "remaining" the web check-in drawer caps at. Status
+    // cannot answer this for a QT asset: it stays AVAILABLE while some of its
+    // units are still out.
     const hasCheckinable = assets.some((a) => {
       if (a.type === AssetType.QUANTITY_TRACKED) {
         const rem = remainingByAsset.get(a.id);

--- a/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.locations.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.locations.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Response-contract test for the location the mobile booking detail endpoint
+ * sends with each asset. The companion prints it under the asset's title, on
+ * standalone rows and kit members alike, and searches it, so three things are
+ * a contract the app depends on:
+ *
+ * 1. Each asset carries `location: { id, name }` — its primary placement on
+ *    the `AssetLocation` pivot — or `location: null` when it is unplaced.
+ * 2. The pivot itself never reaches the payload; `location` is the one field.
+ * 3. The query asks for exactly one placement, in the shared placement order,
+ *    with a tight select, so the primary location is the same on every refresh
+ *    and the payload carries no placement data the app does not read.
+ *
+ * @see {@link file://../../../../app/routes/api+/mobile+/bookings.$bookingId.ts} loader under test
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createLoaderArgs } from "@mocks/remix";
+
+import { db } from "~/database/db.server";
+import type * as MobileAuthServer from "~/modules/api/mobile-auth.server";
+import {
+  requireMobileAuth,
+  requireOrganizationAccess,
+  getMobileUserContext,
+} from "~/modules/api/mobile-auth.server";
+import { ASSET_LOCATIONS_INCLUDE } from "~/modules/asset/fields";
+import type * as BookingServiceServer from "~/modules/booking/service.server";
+
+import { loader } from "~/routes/api+/mobile+/bookings.$bookingId";
+
+import { assertIsDataWithResponseInit } from "@helpers/assertions";
+import { mobileUserContext } from "@helpers/mobile-user-context";
+
+// @vitest-environment node
+
+// why: db is the integration boundary — the loader reads the booking, and the
+// asset placements under test, through `booking.findFirst`. The kit lookup and
+// the lifecycle-progress roll-up's two reads are orthogonal here, so they stub
+// to empty.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    booking: { findFirst: vi.fn() },
+    kit: { findMany: vi.fn().mockResolvedValue([]) },
+    bookingAsset: { findMany: vi.fn().mockResolvedValue([]) },
+    partialBookingCheckout: { findMany: vi.fn().mockResolvedValue([]) },
+  },
+}));
+
+// why: JWT validation and org-membership resolution are out of scope; the
+// remaining exports stay real so nothing else is silently replaced.
+vi.mock("~/modules/api/mobile-auth.server", async () => {
+  const actual = await vi.importActual<typeof MobileAuthServer>(
+    "~/modules/api/mobile-auth.server"
+  );
+  return {
+    ...actual,
+    requireMobileAuth: vi.fn(),
+    requireOrganizationAccess: vi.fn(),
+    assertMobileCanUseBookings: vi.fn(),
+    getMobileUserContext: vi.fn(),
+  };
+});
+
+// why: the QT-remaining helpers hit `tx.bookingAsset` / `tx.consumptionLog`
+// directly rather than the delegates mocked above, and per-asset remaining is
+// unrelated to the location under test.
+vi.mock("~/modules/booking/service.server", async () => {
+  const actual = await vi.importActual<typeof BookingServiceServer>(
+    "~/modules/booking/service.server"
+  );
+  return {
+    ...actual,
+    computeBookingAssetRemaining: vi.fn().mockResolvedValue(0),
+    computeBookingAssetRemainingToCheckOut: vi.fn().mockResolvedValue(0),
+    getPartiallyCheckedInAssetIds: vi.fn().mockResolvedValue([]),
+  };
+});
+
+// why: the loader reads workspace booking settings to decide the check-in and
+// kit-counting flags. They do not reach the location under test, so fixed
+// values keep the response deterministic.
+vi.mock("~/modules/booking-settings/service.server", () => ({
+  getBookingSettingsForOrganization: vi.fn().mockResolvedValue({
+    requireExplicitCheckinForAdmin: false,
+    requireExplicitCheckinForSelfService: false,
+    countKitsAsSingleUnit: false,
+  }),
+}));
+
+// why: the loader resolves six booking permissions to build its action flags.
+// Those flags are a different contract from the location under test, and
+// resolving them for real would need the permission tables — so answer a fixed
+// `false` and let the tests assert on the asset rows alone.
+vi.mock("~/utils/permissions/permission.validator.server", () => ({
+  hasPermission: vi.fn().mockResolvedValue(false),
+}));
+
+const findFirstMock = vi.mocked(db.booking.findFirst);
+const requireMobileAuthMock = vi.mocked(requireMobileAuth);
+const requireOrganizationAccessMock = vi.mocked(requireOrganizationAccess);
+const getMobileUserContextMock = vi.mocked(getMobileUserContext);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireMobileAuthMock.mockResolvedValue({
+    user: { id: "user-1" },
+  } as Awaited<ReturnType<typeof requireMobileAuth>>);
+  requireOrganizationAccessMock.mockResolvedValue("org-1");
+  getMobileUserContextMock.mockResolvedValue(
+    mobileUserContext({ roles: [OrganizationRoles.ADMIN] })
+  );
+});
+
+const STORE = { id: "loc-store", name: "Main Store" };
+const VAN = { id: "loc-van", name: "Van 2" };
+const AUDIO = { id: "kit-audio", name: "Audio Package" };
+
+/**
+ * One BookingAsset row for an asset placed at `location` (or unplaced), booked
+ * through `membership` or standalone.
+ */
+function slice({
+  id,
+  assetId,
+  location,
+  membership = null,
+  kit = null,
+}: {
+  id: string;
+  assetId: string;
+  location: { id: string; name: string } | null;
+  membership?: string | null;
+  kit?: { id: string; name: string } | null;
+}) {
+  return {
+    id,
+    quantity: 1,
+    assetKitId: membership,
+    asset: {
+      id: assetId,
+      title: `Asset ${assetId}`,
+      status: "AVAILABLE",
+      type: "INDIVIDUAL",
+      unitOfMeasure: null,
+      consumptionType: null,
+      mainImage: null,
+      category: null,
+      assetKits: membership && kit ? [{ id: membership, kit }] : [],
+      // The pivot as the query projects it: at most one row, the primary.
+      assetLocations: location ? [{ location }] : [],
+    },
+  };
+}
+
+/** A booking row carrying the given slices, with everything else inert. */
+function bookingRow(bookingAssets: ReturnType<typeof slice>[]) {
+  return {
+    id: "booking-1",
+    name: "Load-in",
+    description: null,
+    // DRAFT keeps `getPartiallyCheckedInAssetIds` out of the path.
+    status: "DRAFT",
+    from: null,
+    to: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    creator: null,
+    custodianUserId: null,
+    custodianUser: null,
+    custodianTeamMember: null,
+    tags: [],
+    bookingAssets,
+    modelRequests: [],
+    _count: { bookingAssets: bookingAssets.length },
+  } as never;
+}
+
+/** Runs the loader for the fixture booking and returns its asset rows. */
+async function assetsOf(bookingAssets: ReturnType<typeof slice>[]) {
+  findFirstMock.mockResolvedValue(bookingRow(bookingAssets));
+  const response = await loader(
+    createLoaderArgs({
+      request: new Request(
+        "http://localhost:3000/api/mobile/bookings/booking-1"
+      ),
+      params: { bookingId: "booking-1" },
+    })
+  );
+  assertIsDataWithResponseInit(response);
+  const body = response.data as {
+    booking: { assets: Array<Record<string, unknown> & { id: string }> };
+  };
+  return body.booking.assets;
+}
+
+describe("GET /api/mobile/bookings/:bookingId — where each asset sits", () => {
+  it("sends a placed asset's primary location as { id, name }", async () => {
+    const [asset] = await assetsOf([
+      slice({ id: "ba1", assetId: "a1", location: STORE }),
+    ]);
+
+    expect(asset.location).toEqual({ id: "loc-store", name: "Main Store" });
+  });
+
+  it("sends null for an asset with no placement", async () => {
+    const [asset] = await assetsOf([
+      slice({ id: "ba1", assetId: "a1", location: null }),
+    ]);
+
+    // Present and null, not absent: the app tells "unplaced" apart from an
+    // older server that sends no location at all.
+    expect(asset).toHaveProperty("location", null);
+  });
+
+  it("sends a kit member's own location, as it does for standalone assets", async () => {
+    const assets = await assetsOf([
+      slice({ id: "ba1", assetId: "a1", location: STORE }),
+      slice({
+        id: "ba2",
+        assetId: "a2",
+        location: VAN,
+        membership: "ak2",
+        kit: AUDIO,
+      }),
+    ]);
+
+    const member = assets.find((a) => a.id === "a2");
+    expect(member).toMatchObject({
+      kitId: "kit-audio",
+      location: { id: "loc-van", name: "Van 2" },
+    });
+  });
+
+  it("keeps the placement pivot out of the payload", async () => {
+    const [asset] = await assetsOf([
+      slice({ id: "ba1", assetId: "a1", location: STORE }),
+    ]);
+
+    expect(asset).not.toHaveProperty("assetLocations");
+  });
+
+  it("asks for one placement per asset, in the shared order, with a tight select", async () => {
+    await assetsOf([slice({ id: "ba1", assetId: "a1", location: STORE })]);
+
+    const query = findFirstMock.mock.calls[0]?.[0] as {
+      select: {
+        bookingAssets: {
+          select: { asset: { select: Record<string, unknown> } };
+        };
+      };
+    };
+    expect(
+      query.select.bookingAssets.select.asset.select.assetLocations
+    ).toEqual({
+      select: { location: { select: { id: true, name: true } } },
+      orderBy: ASSET_LOCATIONS_INCLUDE.orderBy,
+      take: 1,
+    });
+  });
+});


### PR DESCRIPTION
## What

On the web booking page every asset row shows where the asset sits, and the list has a search box. On the phone, asset rows showed no location (the endpoint never sent one) and the list could not be searched, so finding one item in a large booking meant scrolling.

- **Server:** the mobile booking detail endpoint sends each asset's primary location as `location: { id, name } | null`. It reads the `AssetLocation` pivot through `getPrimaryLocation`, the same source the web booking page uses, in the shared placement order (`ASSET_LOCATIONS_INCLUDE`). The pivot itself stays out of the payload.
- **Location line:** the companion booking screen shows that location under each asset row, kit members included, drawn like the kit header's location line.
- **Search:** a search box under "Assets & Kits" filters the rows the screen already holds. The endpoint returns the whole booking, so nothing is fetched.

## How the search behaves

- It is a case-insensitive substring match on the trimmed term. It covers title, category, location, kit name, the kit's location and category (from `booking.kits`), and each quantity slice's kit name. That is web's booking search minus the fields the phone does not receive (SAM ID, tags, QR and barcode values). There is no comma-OR, sort menu or location filter.
- A match on any kit member brings the whole kit back, as the web search does. The kit header's count, badge and checkbox, and the removal split, all read the kit's member list, so a search never hands the screen part of a kit.
- Search only narrows what the list shows. The selection survives any change of term, and the floating button counts all of it. Removal (`splitRemovalSelection`), the select-mode reveal and the section counts keep reading rows built from the whole booking, so a selection made before a search splits the same way whatever is on screen.
- Leaving a select mode keeps the term, and clearing the term restores the full list. With no match, the list says "No assets match". The box stays while a term is set, so a term can always be cleared.
- On focus the list scrolls the box to the top and adds the keyboard's height below the rows, so results stay visible while typing. A row tap selects on the first press while the keyboard is up.

## Compatibility

- `location` is additive, and older clients ignore it.
- The client treats it as optional. Against a server without it, rows render as before and a location term finds nothing. This was checked on the simulator by running the new app against the previous loader.
- Kit rows are unchanged. They already show the kit's own location.

## Tests

- **Route test** `bookings.$bookingId.locations.test.ts`: a placed asset gets `{ id, name }` and an unplaced one `null`; a kit member carries its own location; the pivot is not in the payload; the query asks for one ordered placement with a tight select. It fails 5 of 5 against the previous loader.
- **Companion node tests** `lib/booking-search.test.ts`: hits on each searchable field, whole-kit re-expansion, server order, blank term returning the same array, no match, a payload without `location` or `kits`, slice kit names, and a found kit's header still counting every member.
- **Maestro flow** `19-asset-locations-and-search.yaml`: fixture-dependent, read-only, no-login. It covers the location lines, search by kit name and by location, the empty state, the selection kept across terms, a kit found through one member selecting all of its members, and the term kept after leaving a select mode. It passes on the iPhone 17 simulator. Its QA fixture has "ZZX Audio Package" placed at Studio and "ZZX Standalone Fixture 01" at Mobile Lab 2.

## Checks

- `pnpm --filter @shelf/companion typecheck`, `lint` and `test` pass.
- Webapp typecheck and lint pass, and so do all `bookings.$bookingId*` route tests.
- `react-doctor` reports no errors. Its warnings on the booking screen (component size, `useState` count, `@expo/vector-icons`) predate this change.

The server change ships with a webapp deploy. The client parts work against both the previous and the new server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search booking assets by name, category, kit, or location.
  * View primary locations for assets and kit members in booking details.
  * Select kits as atomic units with clear kit and asset counts.
  * Scan assets for checkout when permitted.
  * Selection state persists while filtering, clearing searches, and leaving selection mode.

* **Updates**
  * Booking details remain compatible when location data is unavailable.
  * Checkout availability now reflects asset quantities, permissions, and restricted-role ownership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->